### PR TITLE
fix: 공지사항 검색 화면에서 5개더 로드 버튼을 누르고 다시 검색하면 정보가 중첩되는 문제 해결

### DIFF
--- a/Koin/Presentation/NoticeList/NoticeListTableView/NoticeListTableView.swift
+++ b/Koin/Presentation/NoticeList/NoticeListTableView/NoticeListTableView.swift
@@ -55,10 +55,11 @@ final class NoticeListTableView: UITableView {
         reloadSections(indexSet, with: .automatic)
     }
     
-    func updateSearchedResult(noticeArticleList: [NoticeArticleDTO]) {
-        
+    func updateSearchedResult(noticeArticleList: [NoticeArticleDTO], isNewKeyword: Bool) {
+        if isNewKeyword {
+            self.noticeArticleList = []
+        }
         self.noticeArticleList.append(contentsOf: noticeArticleList)
-        
         isForSearch = true
         let indexSet = IndexSet(integer: 1)
         reloadSections(indexSet, with: .automatic)

--- a/Koin/Presentation/NoticeSearch/NoticeSearchViewController.swift
+++ b/Koin/Presentation/NoticeSearch/NoticeSearchViewController.swift
@@ -123,8 +123,8 @@ final class NoticeSearchViewController: CustomViewController, UIGestureRecognize
                 self?.updateRecommendedHotWord(keyWords: keyWords)
             case .updateRecentSearchedWord(words: let words):
                 self?.updateRecentSearchedWord(words: words)
-            case let .updateSearchedrsult(searchedResult, isLastPage):
-                self?.updateSearchedResult(searchedResult: searchedResult, isLastPage: isLastPage)
+            case let .updateSearchedrsult(searchedResult, isLastPage, isNewPage):
+                self?.updateSearchedResult(searchedResult: searchedResult, isLastPage: isLastPage, isNewPage: isNewPage)
             }
         }.store(in: &subscriptions)
         
@@ -140,7 +140,7 @@ final class NoticeSearchViewController: CustomViewController, UIGestureRecognize
         }.store(in: &subscriptions)
         
         noticeListTableView.tapListLoadButtnPublisher.sink { [weak self] page in
-            self?.inputSubject.send(.fetchSearchedResult(page, nil))
+            self?.inputSubject.send(.fetchSearchedResult(page, nil, false))
         }.store(in: &subscriptions)
        
         noticeListTableView.tapNoticePublisher.sink { [weak self] noticeId in
@@ -185,7 +185,7 @@ extension NoticeSearchViewController {
         if let text = textField.text?.trimmingCharacters(in: .whitespacesAndNewlines), !text.isEmpty {
             IndicatorView.show()
             inputSubject.send(.searchWord(text, Date(), 0))
-            inputSubject.send(.fetchSearchedResult(1, text))
+            inputSubject.send(.fetchSearchedResult(1, text, true))
             IndicatorView.dismiss()
         }
         textField.text = ""
@@ -199,7 +199,7 @@ extension NoticeSearchViewController {
         if let text = textField.text?.trimmingCharacters(in: .whitespacesAndNewlines), !text.isEmpty {
             IndicatorView.show()
             inputSubject.send(.searchWord(text, Date(), 0))
-            inputSubject.send(.fetchSearchedResult(1, text))
+            inputSubject.send(.fetchSearchedResult(1, text, true))
             IndicatorView.dismiss()
         }
         textField.text = ""
@@ -214,7 +214,7 @@ extension NoticeSearchViewController {
         recentSearchTableView.updateRecentSearchedWords(words: words)
     }
     
-    private func updateSearchedResult(searchedResult: [NoticeArticleDTO], isLastPage: Bool) {
+    private func updateSearchedResult(searchedResult: [NoticeArticleDTO], isLastPage: Bool, isNewPage: Bool) {
         [popularKeyWordGuideLabel, recommendedSearchCollectionView, recentSearchDataGuideLabel, deleteRecentSearchDataButton, recentSearchTableView].forEach {
             $0.isHidden = true
         }
@@ -225,7 +225,7 @@ extension NoticeSearchViewController {
         else {
             emptyNoticeGuideLabel.isHidden = true
             noticeListTableView.isHidden = false
-            noticeListTableView.updateSearchedResult(noticeArticleList: searchedResult)
+            noticeListTableView.updateSearchedResult(noticeArticleList: searchedResult, isNewKeyword: isNewPage)
         }
     }
 }

--- a/Koin/Presentation/NoticeSearch/NoticeSearchViewModel.swift
+++ b/Koin/Presentation/NoticeSearch/NoticeSearchViewModel.swift
@@ -15,13 +15,13 @@ final class NoticeSearchViewModel: ViewModelProtocol {
         case searchWord(String, Date, Int)
         case fetchRecentSearchedWord
         case deleteAllSearchedWords
-        case fetchSearchedResult(Int, String?)
+        case fetchSearchedResult(Int, String?, Bool)
         case logEvent(EventLabelType, EventParameter.EventCategory, Any)
     }
     enum Output {
         case updateHotKeyWord([String])
         case updateRecentSearchedWord([RecentSearchedWordInfo])
-        case updateSearchedrsult([NoticeArticleDTO], Bool)
+        case updateSearchedrsult([NoticeArticleDTO], Bool, Bool)
     }
     
     private let outputSubject = PassthroughSubject<Output, Never>()
@@ -52,8 +52,8 @@ final class NoticeSearchViewModel: ViewModelProtocol {
                 self?.fetchRecentSearchedWord()
             case .deleteAllSearchedWords:
                 self?.deleteAllSearchedWords()
-            case let .fetchSearchedResult(page, keyWord):
-                self?.fetchSearchedResult(page: page, keyWord: keyWord)
+            case let .fetchSearchedResult(page, keyWord, isNewPage):
+                self?.fetchSearchedResult(page: page, keyWord: keyWord, isNewPage: isNewPage)
             case let .logEvent(label, category, value):
                 self?.makeLogAnalyticsEvent(label: label, category: category, value: value)
             }
@@ -95,7 +95,7 @@ extension NoticeSearchViewModel {
         self.outputSubject.send(.updateRecentSearchedWord([]))
     }
     
-    private func fetchSearchedResult(page: Int, keyWord: String?) {
+    private func fetchSearchedResult(page: Int, keyWord: String?, isNewPage: Bool) {
         let requestModel = SearchNoticeArticleRequest(query: keyWord ?? self.keyWord, boardId: nil, page: page, limit: 5)
         if let keyWord = keyWord {
             self.keyWord = keyWord
@@ -106,10 +106,10 @@ extension NoticeSearchViewModel {
             }
         }, receiveValue: { [weak self] articles in
             if articles.currentPage == articles.totalPage {
-                self?.outputSubject.send(.updateSearchedrsult(articles.articles ?? [], true))
+                self?.outputSubject.send(.updateSearchedrsult(articles.articles ?? [], true, isNewPage))
             }
             else {
-                self?.outputSubject.send(.updateSearchedrsult(articles.articles ?? [], false))
+                self?.outputSubject.send(.updateSearchedrsult(articles.articles ?? [], false, isNewPage))
             }
         }).store(in: &subscriptions)
     }


### PR DESCRIPTION
공지사항 검색 시 5개 더 로드하기 버튼을 누르고 다시 검색을 하면, 그전 검색했던 정보와 중첩되어 로드되는 문제 해결