### PR TITLE
fix: 10월 다음 업데이트에 추가할 기능, 버그 해결

### DIFF
--- a/Koin/Core/Extensions/String+.swift
+++ b/Koin/Core/Extensions/String+.swift
@@ -109,7 +109,7 @@ extension String {
             let range = NSMakeRange(0, text.length)
             
             text.enumerateAttribute(NSAttributedString.Key.attachment, in: range, options: []) { (value, _, _) in
-                if let attachment = value as? NSTextAttachment {
+                if let attachment = value as? NSTextAttachment, !imgSrcLists.isEmpty {
                     let imageSrc = imgSrcLists[check]
                     imageSrc.loadImage(from: imageSrc, completion: { image in
                         attachment.image = image

--- a/Koin/Data/DTOs/Decodable/NoticeList/NoticeListDTO.swift
+++ b/Koin/Data/DTOs/Decodable/NoticeList/NoticeListDTO.swift
@@ -94,16 +94,9 @@ extension NoticeArticleDTO {
             let olTags = try document.select("ol")
             let liTags = try document.select("li")
             
-            var emptyPCount = 0
             for paragraph in paragraphs {
                 let paragraphText = try paragraph.text()
-                if paragraphText.isEmpty {
-                    emptyPCount += 1
-                } else {
-                    emptyPCount = 0
-                }
-                
-                if emptyPCount > 1 {
+                if paragraphText.isEmpty && paragraph.children().array().isEmpty {
                     try paragraph.remove()
                 }
                 

--- a/Koin/Data/Repository/DefaultNoticeListRepository.swift
+++ b/Koin/Data/Repository/DefaultNoticeListRepository.swift
@@ -47,7 +47,7 @@ final class DefaultNoticeListRepository: NoticeListRepository {
         return service.fetchRecommendedKeyword(count: count)
     }
     
-    func downloadNoticeAttachment(downloadUrl: String, fileName: String) -> AnyPublisher<Void, ErrorResponse> {
+    func downloadNoticeAttachment(downloadUrl: String, fileName: String) -> AnyPublisher<URL?, ErrorResponse> {
         return service.downloadNoticeAttachment(downloadUrl: downloadUrl, fileName: fileName)
     }
     

--- a/Koin/Data/Service/NetworkService.swift
+++ b/Koin/Data/Service/NetworkService.swift
@@ -117,12 +117,11 @@ class NetworkService {
         .eraseToAnyPublisher()
     }
     
-    func downloadFiles(api: URLRequest, fileName: String) -> AnyPublisher<Void, ErrorResponse> {
+    func downloadFiles(api: URLRequest, fileName: String) -> AnyPublisher<URL?, ErrorResponse> {
         let fileManager = FileManager.default
         guard let documentsDirectory = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first else { return Fail(error: ErrorResponse(code: "001", message: "파일 저장 위치 찾기 실패")).eraseToAnyPublisher() }
-        print(documentsDirectory)
+        let fileUrl = documentsDirectory.appendingPathComponent(fileName)
         let destination: DownloadRequest.Destination = { _, _ in
-            let fileUrl = documentsDirectory.appendingPathComponent(fileName)
             return (fileUrl, [.removePreviousFile, .createIntermediateDirectories])
         }
         
@@ -136,7 +135,7 @@ class NetworkService {
                 
                 if 200..<300 ~= httpResponse.statusCode {
                     print("File is downloaded")
-                    return
+                    return documentsDirectory
                 } else {
                     if let error = response.error {
                         print("Download Failed - \(error)")
@@ -144,6 +143,7 @@ class NetworkService {
                         throw ErrorResponse(code: "\(httpResponse.statusCode)", message: "알 수 없는 에러")
                     }
                 }
+                return nil
             }
             .mapError { error -> ErrorResponse in
                 self.handleError(error)

--- a/Koin/Data/Service/NoticeListService.swift
+++ b/Koin/Data/Service/NoticeListService.swift
@@ -17,7 +17,7 @@ protocol NoticeListService {
     func deleteNotificationKeyword(requestModel: NoticeKeywordDTO) -> AnyPublisher<Void, ErrorResponse>
     func fetchMyNotificationKeyword() -> AnyPublisher<NoticeKeywordsFetchResult, ErrorResponse>
     func fetchRecommendedKeyword(count: Int?) -> AnyPublisher<NoticeRecommendedKeywordDTO, Error>
-    func downloadNoticeAttachment(downloadUrl: String, fileName: String) -> AnyPublisher<Void, ErrorResponse>
+    func downloadNoticeAttachment(downloadUrl: String, fileName: String) -> AnyPublisher<URL?, ErrorResponse>
     func manageRecentSearchedWord(name: String, date: Date, actionType: Int)
     func fetchRecentSearchedWord() -> [RecentSearchedWordInfo]
 }
@@ -118,7 +118,7 @@ final class DefaultNoticeService: NoticeListService {
         }
     }
     
-    func downloadNoticeAttachment(downloadUrl: String, fileName: String) -> AnyPublisher<Void, ErrorResponse> {
+    func downloadNoticeAttachment(downloadUrl: String, fileName: String) -> AnyPublisher<URL?, ErrorResponse> {
         guard let url = URL(string: downloadUrl) else {
             return Fail(error: ErrorResponse(code: "", message: "URL이 유효하지 않습니다."))
                 .eraseToAnyPublisher()

--- a/Koin/Domain/Repository/NoticeListRepository.swift
+++ b/Koin/Domain/Repository/NoticeListRepository.swift
@@ -17,7 +17,7 @@ protocol NoticeListRepository {
     func deleteNotificationKeyword(requestModel: NoticeKeywordDTO) -> AnyPublisher<Void, ErrorResponse>
     func fetchNotificationKeyword() -> AnyPublisher<NoticeKeywordsFetchResult, ErrorResponse>
     func fetchRecommendedKeyword(count: Int?) -> AnyPublisher<NoticeRecommendedKeywordDTO, Error>
-    func downloadNoticeAttachment(downloadUrl: String, fileName: String) -> AnyPublisher<Void, ErrorResponse>
+    func downloadNoticeAttachment(downloadUrl: String, fileName: String) -> AnyPublisher<URL?, ErrorResponse>
     func manageRecentSearchedWord(name: String, date: Date, actionType: Int)
     func fetchRecentSearchedWord() -> [RecentSearchedWordInfo]
 }

--- a/Koin/Domain/UseCase/NoticeList/DownloadNoticeAttachmentsUseCase.swift
+++ b/Koin/Domain/UseCase/NoticeList/DownloadNoticeAttachmentsUseCase.swift
@@ -9,7 +9,7 @@ import Combine
 import Foundation
 
 protocol DownloadNoticeAttachmentsUseCase {
-    func execute(downloadUrl: String, fileName: String) -> AnyPublisher<Void, ErrorResponse>
+    func execute(downloadUrl: String, fileName: String) -> AnyPublisher<URL?, ErrorResponse>
 }
 
 final class DefaultDownloadNoticeAttachmentsUseCase: DownloadNoticeAttachmentsUseCase {
@@ -19,7 +19,7 @@ final class DefaultDownloadNoticeAttachmentsUseCase: DownloadNoticeAttachmentsUs
         self.noticeRepository = noticeRepository
     }
     
-    func execute(downloadUrl: String, fileName: String) -> AnyPublisher<Void, ErrorResponse> {
+    func execute(downloadUrl: String, fileName: String) -> AnyPublisher<URL?, ErrorResponse> {
         return noticeRepository.downloadNoticeAttachment(downloadUrl: downloadUrl, fileName: fileName).eraseToAnyPublisher()
     }
 }

--- a/Koin/Domain/UseCase/NoticeList/SearchNoticeArticlesUseCase.swift
+++ b/Koin/Domain/UseCase/NoticeList/SearchNoticeArticlesUseCase.swift
@@ -20,6 +20,6 @@ final class DefaultSearchNoticeArticlesUseCase: SearchNoticeArticlesUseCase {
     }
     
     func execute(requestModel: SearchNoticeArticleRequest) -> AnyPublisher<NoticeListDTO, Error> {
-        return noticeRepository.searchNoticeArticle(requestModel: requestModel).eraseToAnyPublisher()
+        return noticeRepository.searchNoticeArticle(requestModel: requestModel).map { $0.toDomain() }.eraseToAnyPublisher()
     }
 }

--- a/Koin/Presentation/ManageNoticeKeyWord/ManageNoticeKeywordViewController.swift
+++ b/Koin/Presentation/ManageNoticeKeyWord/ManageNoticeKeywordViewController.swift
@@ -160,7 +160,9 @@ final class ManageNoticeKeywordViewController: CustomViewController {
             }
         }.store(in: &subscriptions)
         
-        recommendedKeywordCollectionView.recommendedKeywordPublisher.sink { [weak self] keyword in
+        recommendedKeywordCollectionView.recommendedKeywordPublisher
+            .debounce(for: .milliseconds(250), scheduler: RunLoop.main)
+            .sink { [weak self] keyword in
             self?.inputSubject.send(.addKeyword(keyword: keyword, isRecommended: true))
         }.store(in: &subscriptions)
         

--- a/Koin/Presentation/NoticeData/NoticeDataViewController.swift
+++ b/Koin/Presentation/NoticeData/NoticeDataViewController.swift
@@ -149,8 +149,8 @@ final class NoticeDataViewController: CustomViewController, UIGestureRecognizerD
                 self?.updateNoticeData(noticeData: noticeData)
             case let .updatePopularArticles(notices):
                 self?.updatePopularArticle(notices: notices)
-            case let .updateActivityIndictor(isStarted, fileName):
-                self?.updateActivityIndicator(isStarted: isStarted, fileName: fileName)
+            case let .updateActivityIndictor(isStarted, fileName, downloadedPath):
+                self?.updateActivityIndicator(isStarted: isStarted, fileName: fileName, downloadedPath: downloadedPath)
             }
         }.store(in: &subscriptions)
         
@@ -255,14 +255,14 @@ extension NoticeDataViewController {
         hotNoticeArticlesTableView.updatePopularArticles(notices: notices)
     }
     
-    private func updateActivityIndicator(isStarted: Bool, fileName: String?) {
+    private func updateActivityIndicator(isStarted: Bool, fileName: String?, downloadedPath: URL?) {
         if isStarted {
             IndicatorView.show()
         }
         else {
             IndicatorView.dismiss()
-            if let fileName = fileName {
-                presentAlert(title: "\(fileName) 다운로드 완료", preferredStyle: .alert, with: [])
+            if let fileName = fileName, let path = downloadedPath {
+                presentAlert(title: "\(fileName) 다운로드 완료 \n \(path)에 저장", preferredStyle: .alert, with: [])
             }
         }
     }

--- a/Koin/Presentation/NoticeData/NoticeDataViewModel.swift
+++ b/Koin/Presentation/NoticeData/NoticeDataViewModel.swift
@@ -19,7 +19,7 @@ final class NoticeDataViewModel: ViewModelProtocol {
     enum Output {
         case updateNoticeData(NoticeDataInfo)
         case updatePopularArticles([NoticeArticleDTO])
-        case updateActivityIndictor(Bool, String?)
+        case updateActivityIndictor(Bool, String?, URL?)
     }
     
     private let fetchNoticeDataUseCase: FetchNoticeDataUseCase
@@ -59,16 +59,16 @@ final class NoticeDataViewModel: ViewModelProtocol {
 
 extension NoticeDataViewModel {
     private func getNoticeData() {
-        outputSubject.send(.updateActivityIndictor(true, nil))
+        outputSubject.send(.updateActivityIndictor(true, nil, nil))
         let request = FetchNoticeDataRequest(noticeId: noticeId)
         fetchNoticeDataUseCase.execute(request: request).sink(receiveCompletion: { [weak self] completion in
-            self?.outputSubject.send(.updateActivityIndictor(false, nil))
+            self?.outputSubject.send(.updateActivityIndictor(false, nil, nil))
             if case let .failure(error) = completion {
                 Log.make().error("\(error)")
             }
         }, receiveValue: { [weak self] noticeData in
             self?.outputSubject.send(.updateNoticeData(noticeData))
-            self?.outputSubject.send(.updateActivityIndictor(false, nil))
+            self?.outputSubject.send(.updateActivityIndictor(false, nil, nil))
         }).store(in: &subscriptions)
     }
     
@@ -83,14 +83,14 @@ extension NoticeDataViewModel {
     }
     
     private func downloadFile(downloadUrl: String, fileName: String) {
-        outputSubject.send(.updateActivityIndictor(true, nil))
+        outputSubject.send(.updateActivityIndictor(true, nil, nil))
         downloadNoticeAttachmentUseCase.execute(downloadUrl: downloadUrl, fileName: fileName).sink(receiveCompletion: { [weak self] completion in
-            self?.outputSubject.send(.updateActivityIndictor(false, fileName))
+            self?.outputSubject.send(.updateActivityIndictor(false, nil, nil))
             if case let .failure(error) = completion {
                 Log.make().error("\(error)")
             }
-        }, receiveValue: { [weak self] in
-            self?.outputSubject.send(.updateActivityIndictor(false, fileName))
+        }, receiveValue: { [weak self] downloadedPath in
+            self?.outputSubject.send(.updateActivityIndictor(false, fileName, downloadedPath))
         }).store(in: &subscriptions)
     }
     

--- a/Koin/Presentation/NoticeList/NoticeListTableView/NoticeListTableView.swift
+++ b/Koin/Presentation/NoticeList/NoticeListTableView/NoticeListTableView.swift
@@ -200,7 +200,7 @@ extension NoticeListTableView: UITableViewDelegate {
         if !isForSearch && section == 1 {
             return 95
         }
-        else if isForSearch && section == 1 && noticeArticleList.count / 5 < 5 {
+        else if isForSearch && section == 1 && noticeArticleList.count / 5 > 5 {
             return 58
         }
         else {


### PR DESCRIPTION
## #️⃣연관된 이슈

- #70 

## 📝작업 내용

- 공지사항 상세 화면에서 공백을 줄이려다가 이미지 파싱이 잘못된 버그 수정
- 공지사항 상세 화면에서 다운로드 받은 파일의 경로를 표시
- 키워드 추가 시 연속으로 여러 번 눌렀을 경우에 debouncing을 하여 키워드 중복추가를 막음

### 스크린샷 (선택)

<img width="253" alt="image" src="https://github.com/user-attachments/assets/52cb1312-bf4e-4406-9824-a987171eea49">
<img width="326" alt="image" src="https://github.com/user-attachments/assets/55e64540-5bf2-4c36-91a4-98e35808ff63">


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
