### PR TITLE
add: 공지사항 원본 바로가기 버튼 추가

### DIFF
--- a/Koin/Data/DTOs/Decodable/NoticeList/NoticeListDTO.swift
+++ b/Koin/Data/DTOs/Decodable/NoticeList/NoticeListDTO.swift
@@ -27,6 +27,7 @@ struct NoticeArticleDTO: Decodable {
     let hit: Int
     let content: String?
     let updatedAt: String
+    let url: String?
     let attachments: [NoticeAttachmentDTO]?
     let prevId: Int?
     let nextId: Int?
@@ -35,7 +36,7 @@ struct NoticeArticleDTO: Decodable {
     enum CodingKeys: String, CodingKey {
         case id
         case boardId = "board_id"
-        case title, author, hit, content, attachments
+        case title, author, hit, content, attachments, url
         case prevId = "prev_id"
         case nextId = "next_id"
         case updatedAt = "updated_at"
@@ -68,7 +69,7 @@ extension NoticeListDTO {
 
 extension NoticeArticleDTO {
     func toDomain() -> NoticeDataInfo {
-        return NoticeDataInfo(title: title, boardId: boardId, content: content ?? "", author: author, hit: hit, prevId: prevId, nextId: nextId, attachments: attachments ?? [], registeredAt: registeredAt)
+        return NoticeDataInfo(title: title, boardId: boardId, content: content ?? "", author: author, hit: hit, prevId: prevId, nextId: nextId, attachments: attachments ?? [], url: url, registeredAt: registeredAt)
     }
     
     func toDomainWithChangedDate() -> NoticeArticleDTO {
@@ -77,7 +78,7 @@ extension NoticeArticleDTO {
         let date = dateFormatter.date(from: registeredAt) ?? Date()
         let newDate = date.formatDateToMMDDE()
         let newTitle = title.replacingOccurrences(of: "\n", with: "")
-        return NoticeArticleDTO(id: id, boardId: boardId, title: newTitle, author: author, hit: hit, content: modifyFontInHtml(html: content ?? ""), updatedAt: updatedAt, attachments: attachments ?? [], prevId: prevId, nextId: nextId, registeredAt: newDate)
+        return NoticeArticleDTO(id: id, boardId: boardId, title: newTitle, author: author, hit: hit, content: modifyFontInHtml(html: content ?? ""), updatedAt: updatedAt, url: url, attachments: attachments ?? [], prevId: prevId, nextId: nextId, registeredAt: newDate)
     }
     
     private func modifyFontInHtml(html: String) -> String? {

--- a/Koin/Domain/Model/NoticeList/NoticeDataInfo.swift
+++ b/Koin/Domain/Model/NoticeList/NoticeDataInfo.swift
@@ -16,5 +16,6 @@ struct NoticeDataInfo {
     let prevId: Int?
     let nextId: Int?
     let attachments: [NoticeAttachmentDTO]
+    let url: String?
     let registeredAt: String
 }

--- a/Koin/Presentation/NoticeData/NoticeDataViewController.swift
+++ b/Koin/Presentation/NoticeData/NoticeDataViewController.swift
@@ -16,7 +16,8 @@ final class NoticeDataViewController: CustomViewController, UIGestureRecognizerD
     private let viewModel: NoticeDataViewModel
     private let inputSubject: PassthroughSubject<NoticeDataViewModel.Input, Never> = .init()
     private var subscriptions: Set<AnyCancellable> = []
-    
+    private var noticeUrl = ""
+ 
     // MARK: - UI Components
     
     private let titleWrappedView = UIView().then {
@@ -157,16 +158,7 @@ final class NoticeDataViewController: CustomViewController, UIGestureRecognizerD
 
 extension NoticeDataViewController {
     @objc private func tapUrlRedirectButton(sender: UIButton) {
-        var redirectUrl = ""
-        switch sender.tag {
-        case 1:
-            print("원본글")
-        case 2:
-            redirectUrl = "https://portal.koreatech.ac.kr"
-        default:
-            redirectUrl = "https://job.koreatech.ac.kr"
-        }
-        if let url = URL(string: redirectUrl), UIApplication.shared.canOpenURL(url) {
+        if let url = URL(string: noticeUrl), UIApplication.shared.canOpenURL(url) {
             UIApplication.shared.open(url, options: [:], completionHandler: nil)
         }
      }
@@ -250,15 +242,17 @@ extension NoticeDataViewController {
         
         if noticeData.boardId == 12 || noticeData.boardId == 13 {
             urlRedirectButton.setTitle("아우누리 바로가기", for: .normal)
-            urlRedirectButton.tag = 2
+            noticeUrl = "https://portal.koreatech.ac.kr"
         }
         else if noticeData.boardId == 8 {
             urlRedirectButton.setTitle("학생종합경력개발 바로가기", for: .normal)
-            urlRedirectButton.tag = 3
+            noticeUrl = "https://job.koreatech.ac.kr"
         }
         else if noticeData.boardId != 13 {
             urlRedirectButton.setTitle("원본 글 바로가기", for: .normal)
-            urlRedirectButton.tag = 1
+            if let url = noticeData.url {
+                noticeUrl = url
+            }
         }
         else {
             urlRedirectButton.isHidden = true

--- a/Koin/Presentation/NoticeData/NoticeDataViewController.swift
+++ b/Koin/Presentation/NoticeData/NoticeDataViewController.swift
@@ -60,19 +60,12 @@ final class NoticeDataViewController: CustomViewController, UIGestureRecognizerD
         $0.setTitle("목록", for: .normal)
     }
     
-    /* 변경된 명세로 이번 배포에서 숨김처리
-    private let previousButton = UIButton().then {
-        $0.setTitle("이전 글", for: .normal)
-    }
-    
-    private let nextButton = UIButton().then {
-        $0.setTitle("다음 글", for: .normal)
-    } */
-    
     private let popularNoticeWrappedView = UIView().then {
         $0.backgroundColor = .white
     }
     
+    private let urlRedirectButton = UIButton()
+        
     private let popularNoticeGuideLabel = UILabel().then {
         $0.font = UIFont.appFont(.pretendardBold, size: 16)
         $0.textColor = .appColor(.neutral800)
@@ -121,14 +114,10 @@ final class NoticeDataViewController: CustomViewController, UIGestureRecognizerD
     override func viewDidLoad() {
         super.viewDidLoad()
         inventoryButton.addTarget(self, action: #selector(tapInventoryButton), for: .touchUpInside)
+        urlRedirectButton.addTarget(self, action: #selector(tapUrlRedirectButton), for: .touchUpInside)
         contentTextView.isUserInteractionEnabled = true
         contentTextView.isEditable = false
         contentTextView.delegate = self
-        /*
-        nextButton.isHidden = true
-        previousButton.isHidden = true
-        previousButton.addTarget(self, action: #selector(tapOtherNoticeBtn), for: .touchUpInside)
-        nextButton.addTarget(self, action: #selector(tapOtherNoticeBtn), for: .touchUpInside) */
         bind()
         setNavigationTitle(title: "공지사항")
         inputSubject.send(.getNoticeData)
@@ -167,6 +156,21 @@ final class NoticeDataViewController: CustomViewController, UIGestureRecognizerD
 }
 
 extension NoticeDataViewController {
+    @objc private func tapUrlRedirectButton(sender: UIButton) {
+        var redirectUrl = ""
+        switch sender.tag {
+        case 1:
+            print("원본글")
+        case 2:
+            redirectUrl = "https://portal.koreatech.ac.kr"
+        default:
+            redirectUrl = "https://job.koreatech.ac.kr"
+        }
+        if let url = URL(string: redirectUrl), UIApplication.shared.canOpenURL(url) {
+            UIApplication.shared.open(url, options: [:], completionHandler: nil)
+        }
+     }
+    
     @objc private func tapInventoryButton() {
         inputSubject.send(.logEvent(EventParameter.EventLabel.Campus.inventory, .click, "목록"))
         guard let navigationController = navigationController else { return }
@@ -184,12 +188,6 @@ extension NoticeDataViewController {
         }
     }
     
-    /*
-    @objc private func tapOtherNoticeBtn(sender: UIButton) {
-        if let noticeId = sender == previousButton ? viewModel.previousNoticeId : viewModel.nextNoticeId {
-            navigateToOtherNoticeDataPage(noticeId: noticeId)
-        }
-    }*/
     
     private func navigateToOtherNoticeDataPage(noticeId: Int) {
         let noticeListService = DefaultNoticeService()
@@ -249,6 +247,22 @@ extension NoticeDataViewController {
             attachmentGuideLabel.isHidden = true
             noticeAttachmentsTableView.isHidden = true
         }
+        
+        if noticeData.boardId == 12 || noticeData.boardId == 13 {
+            urlRedirectButton.setTitle("아우누리 바로가기", for: .normal)
+            urlRedirectButton.tag = 2
+        }
+        else if noticeData.boardId == 8 {
+            urlRedirectButton.setTitle("학생종합경력개발 바로가기", for: .normal)
+            urlRedirectButton.tag = 3
+        }
+        else if noticeData.boardId != 13 {
+            urlRedirectButton.setTitle("원본 글 바로가기", for: .normal)
+            urlRedirectButton.tag = 1
+        }
+        else {
+            urlRedirectButton.isHidden = true
+        }
     }
     
     private func updatePopularArticle(notices: [NoticeArticleDTO]) {
@@ -293,14 +307,13 @@ extension NoticeDataViewController {
     }
     
     private func setUpButtons() {
-        //[inventoryButton, previousButton, nextButton]
-        [inventoryButton].forEach {
+        [inventoryButton, urlRedirectButton].forEach {
             $0.titleLabel?.font = .appFont(.pretendardMedium, size: 12)
             $0.backgroundColor = .appColor(.neutral300)
             $0.setTitleColor(.appColor(.neutral600), for: .normal)
             $0.layer.cornerRadius = 4
+            $0.contentEdgeInsets = .init(top: 6, left: 12, bottom: 6, right: 12)
         }
-        //previousButton.backgroundColor = .appColor(.neutral400)
     }
     
     private func setUpLayOuts() {
@@ -313,8 +326,7 @@ extension NoticeDataViewController {
         [navigationBarWrappedView, titleGuideLabel, titleLabel, createdDateLabel, separatorDotLabel, nickNameLabel, separatorDot2Label, eyeImageView, hitLabel].forEach {
             titleWrappedView.addSubview($0)
         }
-        //[contentTextView, inventoryButton, previousButton, nextButton].forEach {
-        [contentTextView, inventoryButton, attachmentGuideLabel, noticeAttachmentsTableView].forEach {
+        [contentTextView, inventoryButton, attachmentGuideLabel, noticeAttachmentsTableView, urlRedirectButton].forEach {
             contentWrappedView.addSubview($0)
         }
         [popularNoticeGuideLabel, hotNoticeArticlesTableView].forEach {
@@ -428,26 +440,16 @@ extension NoticeDataViewController {
             inventoryButton.snp.makeConstraints {
                 $0.top.equalTo(noticeAttachmentsTableView.snp.bottom).offset(8)
                 $0.leading.equalToSuperview().offset(24)
-                $0.width.equalTo(45)
                 $0.height.equalTo(31)
                 $0.bottom.equalToSuperview().inset(16)
             }
         }
         
-        /*
-        nextButton.snp.makeConstraints {
+        urlRedirectButton.snp.makeConstraints {
+            $0.top.equalTo(inventoryButton)
+            $0.height.equalTo(31)
             $0.trailing.equalToSuperview().inset(24)
-            $0.top.equalTo(inventoryButton)
-            $0.height.equalTo(31)
-            $0.width.equalTo(59)
         }
-        
-        previousButton.snp.makeConstraints {
-            $0.trailing.equalTo(nextButton.snp.leading).offset(-8)
-            $0.top.equalTo(inventoryButton)
-            $0.height.equalTo(31)
-            $0.width.equalTo(59)
-        }*/
         
         popularNoticeWrappedView.snp.makeConstraints {
             $0.top.equalTo(contentWrappedView.snp.bottom).offset(6)


### PR DESCRIPTION
## #️⃣연관된 이슈
- #72 

## 📝작업 내용
- [x] 버튼 배치
- [x] 학생생활, 현장실습의 경우 아우누리로 이동
- [x] 취업공지의 경우 학생종합경력개발로 이동
- [x] 원본 글 url로 이동
- [ ] 삭제 글일 시 토스트 메시지 띄워주기   

### 스크린샷 (선택)
UIApplication.shared.canOpenURL(url)   

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
