### PR TITLE
log: 리뷰 작성 팝업 및 리뷰 신고 팝업 로그인하기 로깅 구현

### DIFF
--- a/Koin/Domain/Model/Log/EventParameter.swift
+++ b/Koin/Domain/Model/Log/EventParameter.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 
-
 protocol EventLabelType {
     var rawValue: String { get }
     var team: String { get }
@@ -69,6 +68,7 @@ enum EventParameter {
             case benefitShopCategoriesEvent = "benefit_shop_categories_event"
             case benefitShopClick = "benefit_shop_click"
             case benefitShopCall = "benefit_shop_call"
+            case loginPrompt = "login_prompt"
             var team: String {
                 return "BUSINESS"
             }

--- a/Koin/Presentation/ShopData/SubViews/ShopDataPageViewControllers/ReviewListViewController.swift
+++ b/Koin/Presentation/ShopData/SubViews/ShopDataPageViewControllers/ReviewListViewController.swift
@@ -204,6 +204,7 @@ final class ReviewListViewController: UIViewController {
         
         reviewWriteLoginModalViewController.loginButtonPublisher.sink { [weak self] in
             self?.inputSubject.send(.logEvent(EventParameter.EventLabel.Business.shopDetailViewReviewWriteLogin, .click, self?.viewModel.shopName ?? ""))
+            self?.inputSubject.send(.checkLogin(nil, source: .reviewWrite))
             self?.navigateToLogin()
         }.store(in: &cancellables)
         
@@ -225,6 +226,7 @@ final class ReviewListViewController: UIViewController {
         reviewReportLoginModalViewController.loginButtonPublisher.sink { [weak self] in
             self?.navigateToLogin()
             self?.inputSubject.send(.logEvent(EventParameter.EventLabel.Business.shopDetailViewReviewReportLogin, .click, self?.viewModel.shopName ?? ""))
+            self?.inputSubject.send(.checkLogin(nil, source: .reviewReport))
         }.store(in: &cancellables)
         
         reviewReportLoginModalViewController.cancelButtonPublisher.sink { [weak self] in
@@ -253,7 +255,7 @@ final class ReviewListViewController: UIViewController {
         }.store(in: &cancellables)
         
         reviewListCollectionView.reportButtonPublisher.sink { [weak self] parameter in
-            self?.inputSubject.send(.checkLogin(parameter))
+            self?.inputSubject.send(.checkLogin(parameter, source: .reviewReport))
         }.store(in: &cancellables)
         
         reviewListCollectionView.imageTapPublisher.sink { [weak self] image in
@@ -272,7 +274,7 @@ final class ReviewListViewController: UIViewController {
 extension ReviewListViewController {
     
     @objc private func writeReviewButtonTapped() {
-        inputSubject.send(.checkLogin(nil))
+        inputSubject.send(.checkLogin(nil, source: .reviewWrite))
     }
     
     private func navigateToReportReview(parameter: (Int, Int)) {


### PR DESCRIPTION
## #️⃣연관된 이슈

- #138  

## 📝작업 내용

> DA 측에서 요청하신 비즈니스팀 리뷰 작성 팝업, 리뷰 신고 팝업 로그인하기 로깅을 구현했습니다.

## 💬리뷰 요구사항

> ReviewListViewModel의 checkoutLogin이 리뷰 작성 팝업, 리뷰 신고 팝업 두 곳에서 호출되어서 어디서 호출되었는지 구분할 필요가 있다고 생각했습니다. 그래서 enum 타입인 LoginSource를 만들어 checkLogin이 어디에서 호출되었는지 구분할 수 있게 구현했습니다. 피드백 부탁드립니다!
