### PR TITLE
feat: 주변 상점 혜택 2초 뒤에 혜택 바뀌는 기능

### DIFF
--- a/Koin/Presentation/Shop/ShopViewControllerA.swift
+++ b/Koin/Presentation/Shop/ShopViewControllerA.swift
@@ -154,9 +154,13 @@ final class ShopViewControllerA: UIViewController {
             searchTextField.resignFirstResponder() // 키보드 내리기
         }
     }
+    
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         eventShopCollectionView.stopAutoScroll()
+        for cell in shopCollectionView.visibleCells {
+            (cell as? ShopInfoCollectionViewCell)?.stopBenefitRotation()
+        }
     }
     
     override func viewWillAppear(_ animated: Bool) {

--- a/Koin/Presentation/Shop/SubViews/ShopInfoCollectionView/ShopInfoCollectionViewCell.swift
+++ b/Koin/Presentation/Shop/SubViews/ShopInfoCollectionView/ShopInfoCollectionViewCell.swift
@@ -9,10 +9,9 @@ import UIKit
 
 final class ShopInfoCollectionViewCell: UICollectionViewCell {
     
-    private let eventLabel: UILabel = {
-        let label = UILabel()
+    private let eventLabel = UILabel().then {
         let attributedString = NSMutableAttributedString(string: "이벤트 ")
-        label.textAlignment = .center
+        $0.textAlignment = .center
         let attributes: [NSAttributedString.Key: Any] = [
             .font: UIFont.appFont(.pretendardMedium, size: 8),
             .foregroundColor: UIColor.appColor(.primary300),
@@ -24,39 +23,32 @@ final class ShopInfoCollectionViewCell: UICollectionViewCell {
         imageAttachment.image = UIImage.appImage(asset: .lamp)
         imageAttachment.bounds = CGRect(x: 0, y: 3, width: 7, height: 7)
         attributedString.append(NSAttributedString(attachment: imageAttachment))
-        label.clipsToBounds = true
-        label.layer.cornerRadius = 8
-        label.layer.borderColor = UIColor.appColor(.primary300).cgColor
-        label.layer.borderWidth = 0.5
-        label.attributedText = attributedString
-        label.backgroundColor = .systemBackground
-        return label
-    }()
+        $0.clipsToBounds = true
+        $0.layer.cornerRadius = 8
+        $0.layer.borderColor = UIColor.appColor(.primary300).cgColor
+        $0.layer.borderWidth = 0.5
+        $0.attributedText = attributedString
+        $0.backgroundColor = .systemBackground
+    }
 
-    private let borderView: UIView = {
-        let view = UIView()
-        view.layer.borderWidth = 1.0
-        view.layer.borderColor = UIColor.appColor(.neutral200).cgColor
-        view.layer.cornerRadius = 5
-        view.clipsToBounds = true
-        return view
-    }()
+    private let borderView = UIView().then {
+        $0.layer.borderWidth = 1.0
+        $0.layer.borderColor = UIColor.appColor(.neutral200).cgColor
+        $0.layer.cornerRadius = 5
+        $0.clipsToBounds = true
+    }
     
-    private let shopTitleLabel: UILabel = {
-        let label = UILabel()
-        label.textColor = UIColor.appColor(.neutral800)
-        label.font = UIFont.appFont(.pretendardMedium, size: 14)
-        label.numberOfLines = 0
-        label.lineBreakMode = .byWordWrapping
-        return label
-    }()
+    private let shopTitleLabel = UILabel().then {
+        $0.textColor = UIColor.appColor(.neutral800)
+        $0.font = UIFont.appFont(.pretendardMedium, size: 14)
+        $0.numberOfLines = 0
+        $0.lineBreakMode = .byWordWrapping
+    }
     
-    private let benefitLabel: UILabel = {
-        let label = UILabel()
-        label.textColor = UIColor.appColor(.primary300)
-        label.font = UIFont.appFont(.pretendardRegular, size: 12)
-        return label
-    }()
+    private let benefitLabel = UILabel().then {
+        $0.textColor = UIColor.appColor(.primary300)
+        $0.font = UIFont.appFont(.pretendardRegular, size: 12)
+    }
     
     private let starImageView = UIImageView().then { _ in
     }
@@ -71,12 +63,10 @@ final class ShopInfoCollectionViewCell: UICollectionViewCell {
         $0.textColor = UIColor.appColor(.neutral500)
     }
     
-    private let shopReadyView: ShopReadyView = {
-        let view = ShopReadyView(frame: .zero)
-        view.layer.cornerRadius = 5
-        view.clipsToBounds = true
-        return view
-    }()
+    private let shopReadyView = ShopReadyView(frame: .zero).then {
+        $0.layer.cornerRadius = 5
+        $0.clipsToBounds = true
+    }
     
     override init(frame: CGRect) {
         super.init(frame: frame)

--- a/Koin/Presentation/Shop/SubViews/ShopInfoCollectionView/ShopInfoCollectionViewCell.swift
+++ b/Koin/Presentation/Shop/SubViews/ShopInfoCollectionView/ShopInfoCollectionViewCell.swift
@@ -8,6 +8,9 @@
 import UIKit
 
 final class ShopInfoCollectionViewCell: UICollectionViewCell {
+    private var benefitTimer: Timer?
+    private var benefitDetails: [String] = []
+    private var currentIndex: Int = 0
     
     private let eventLabel = UILabel().then {
         let attributedString = NSMutableAttributedString(string: "이벤트 ")
@@ -68,6 +71,12 @@ final class ShopInfoCollectionViewCell: UICollectionViewCell {
         $0.clipsToBounds = true
     }
     
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        stopBenefitRotation()
+        benefitLabel.text = nil
+    }
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         configureView()
@@ -91,11 +100,39 @@ final class ShopInfoCollectionViewCell: UICollectionViewCell {
         }
         
         if let detail = info.benefitDetail {
-            benefitLabel.text = info.benefitDetail
+            benefitLabel.text = detail
+            stopBenefitRotation()
         } else {
-            benefitLabel.text = info.benefitDetails.first
+            benefitDetails = info.benefitDetails
+            benefitLabel.text = benefitDetails.first
         }
+        
         benefitLabel.isHidden = info.isOpen ? false : true
+    }
+    
+    func startBenefitRotation() {
+        guard benefitDetails.count > 1 else { return }
+
+        stopBenefitRotation()
+        currentIndex = 0
+
+        benefitTimer = Timer.scheduledTimer(withTimeInterval: 2.0, repeats: true) { [weak self] _ in
+            guard let self = self, !self.benefitDetails.isEmpty else { return }
+            self.currentIndex = (self.currentIndex + 1) % self.benefitDetails.count
+            let nextText = self.benefitDetails[self.currentIndex]
+            self.animateBenefitChange(to: nextText)
+        }
+    }
+
+    func stopBenefitRotation() {
+        benefitTimer?.invalidate()
+        benefitTimer = nil
+    }
+    
+    private func animateBenefitChange(to newText: String) {
+        UIView.transition(with: benefitLabel, duration: 0.25, options: [.transitionCrossDissolve], animations: {
+            self.benefitLabel.text = newText
+        }, completion: nil)
     }
 }
 

--- a/Koin/Presentation/Shop/SubViews/ShopInfoCollectionView/ShopInfoColletionView.swift
+++ b/Koin/Presentation/Shop/SubViews/ShopInfoCollectionView/ShopInfoColletionView.swift
@@ -69,7 +69,6 @@ final class ShopInfoCollectionView: UICollectionView, UICollectionViewDataSource
 }
 
 extension ShopInfoCollectionView {
-    
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
             return isHeaderHidden ? CGSize.zero : CGSize(width: collectionView.bounds.width, height: 25)
         }
@@ -103,8 +102,19 @@ extension ShopInfoCollectionView {
         cell.configure(info: shopItem)
         return cell
     }
+    
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         self.makeAnalyticsForClickStoreList(shops[indexPath.row].name)
         cellTapPublisher.send((shops[indexPath.row].id, shops[indexPath.row].name))
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
+        guard let shopCell = cell as? ShopInfoCollectionViewCell else { return }
+        shopCell.startBenefitRotation()
+    }
+
+    func collectionView(_ collectionView: UICollectionView, didEndDisplaying cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
+        guard let shopCell = cell as? ShopInfoCollectionViewCell else { return }
+        shopCell.stopBenefitRotation()
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

- #143 

## 📝작업 내용

> 한 상점에 2개 이상의 혜택이 있는 상점의 경우, 2초마다 혜택 문구가 변경됩니다. 자연스럽게 변하도록 애니메이션을 추가했습니다.

### 스크린샷 (선택)


## 💬리뷰 요구사항(선택)

> 
