### PR TITLE
log: 유저 아이디 로깅 방식 표준화

### DIFF
--- a/Koin/Core/Workers/UserDataManager.swift
+++ b/Koin/Core/Workers/UserDataManager.swift
@@ -29,14 +29,14 @@ final class UserDataManager {
         }
         self.id = id
 
-        if let studentNumber = userData.studentNumber, !studentNumber.isEmpty {
-            userId = "\(String(studentNumber.prefix(6)))_\(id)"
+        if let studentNumberValue = userData.studentNumber, !studentNumberValue.isEmpty {
+            userId = "\(String(studentNumberValue.prefix(6)))_\(id)"
         } else {
             userId = "anonymous_\(id)"
         }
 
-        if let g = userData.gender {
-            gender = (g == 0) ? "0" : (g == 1) ? "1" : ""
+        if let genderValue = userData.gender {
+            gender = (genderValue == 0) ? "0" : (genderValue == 1) ? "1" : ""
         } else {
             gender = ""
         }

--- a/Koin/Core/Workers/UserDataManager.swift
+++ b/Koin/Core/Workers/UserDataManager.swift
@@ -5,7 +5,6 @@
 //  Created by 김나훈 on 3/6/25.
 //
 
-
 final class UserDataManager {
     static let shared = UserDataManager()
     private(set) var userId: String = ""
@@ -14,30 +13,41 @@ final class UserDataManager {
     private(set) var major: String = ""
     private(set) var nickname: String = ""
     
-    
     private init() {}
     
     func setUserData(userData: UserDTO) {
-        if let studentNumber = userData.studentNumber, !studentNumber.isEmpty {
-            userId = "\(studentNumber.prefix(6))_\(userData.id)"
-        } else {
-            userId = "anonymous_\(userData.id)"
+        guard let id = userData.id else {
+            self.id = 0
+            self.userId = "anonymous"
+            self.gender = ""
+            self.nickname = userData.nickname ?? userData.anonymousNickname ?? ""
+            self.major = userData.major ?? ""
+            return
         }
-        if let genderValue = userData.gender {
-            gender = (genderValue == 0) ? "0" : (genderValue == 1) ? "1" : ""
+        self.id = id
+
+        if let studentNumber = userData.studentNumber, !studentNumber.isEmpty {
+            userId = "\(String(studentNumber.prefix(6)))_\(id)"
+        } else {
+            userId = "anonymous_\(id)"
+        }
+
+        if let g = userData.gender {
+            gender = (g == 0) ? "0" : (g == 1) ? "1" : ""
         } else {
             gender = ""
         }
         nickname = userData.nickname ?? userData.anonymousNickname ?? ""
-        if let id = userData.id {
-            self.id = id
-        }
         major = userData.major ?? ""
     }
+
+    
     func resetUserData() {
         userId = ""
+        id = 0
         gender = ""
         major = ""
+        nickname = ""
     }
     
 }

--- a/Koin/Core/Workers/UserDataManager.swift
+++ b/Koin/Core/Workers/UserDataManager.swift
@@ -5,6 +5,8 @@
 //  Created by 김나훈 on 3/6/25.
 //
 
+import FirebaseAnalytics
+
 final class UserDataManager {
     static let shared = UserDataManager()
     private(set) var userId: String = ""
@@ -22,6 +24,7 @@ final class UserDataManager {
             self.gender = ""
             self.nickname = userData.nickname ?? userData.anonymousNickname ?? ""
             self.major = userData.major ?? ""
+            Analytics.setUserID(self.userId)
             return
         }
         self.id = id
@@ -39,15 +42,16 @@ final class UserDataManager {
         }
         nickname = userData.nickname ?? userData.anonymousNickname ?? ""
         major = userData.major ?? ""
+        Analytics.setUserID(self.userId)
     }
 
-    
     func resetUserData() {
         userId = ""
         id = 0
         gender = ""
         major = ""
         nickname = ""
+        Analytics.setUserID(nil)
     }
     
 }

--- a/Koin/Data/Service/LogAnalyticsService.swift
+++ b/Koin/Data/Service/LogAnalyticsService.swift
@@ -20,7 +20,6 @@ final class GA4AnalyticsService: LogAnalyticsService {
             "event_label": label,
             "event_category": category,
             "value": value,
-            "user_id": UserDataManager.shared.userId,
             "gender": UserDataManager.shared.gender,
             "major": UserDataManager.shared.major
         ]
@@ -35,7 +34,6 @@ final class GA4AnalyticsService: LogAnalyticsService {
             "event_label": label.rawValue,
             "event_category": category.rawValue,
             "value": value,
-            "user_id": UserDataManager.shared.userId,
             "gender": UserDataManager.shared.gender,
             "major": UserDataManager.shared.major
         ]
@@ -47,10 +45,10 @@ final class GA4AnalyticsService: LogAnalyticsService {
             "event_label": label.rawValue,
             "event_category": category.rawValue,
             "value": value,
-            "user_id": UserDataManager.shared.userId,
             "gender": UserDataManager.shared.gender,
             "major": UserDataManager.shared.major
         ]
+        
         if let previousPage = previousPage {
             defaultParameters["previous_page"] = previousPage
         }
@@ -72,7 +70,6 @@ final class GA4AnalyticsService: LogAnalyticsService {
             "event_category": category.rawValue,
             "value": value,
             "custom_session_id": sessionId,
-            "user_id": UserDataManager.shared.userId,
             "gender": UserDataManager.shared.gender,
             "major": UserDataManager.shared.major
         ]


### PR DESCRIPTION
## #️⃣연관된 이슈

- #175 

## 📝작업 내용

> DA에서 요청한 유저 아이디 로깅 방식 표준화 적용

```
현재 user_id가 GA4의 표준 user_id 필드가 아닌, 이벤트 매개변수(event_params) 내에 key가
'user_id'인 커스텀 항목으로 수집되고 있습니다.

올바른 방식: 데이터가 최상위 레벨의 user_id 컬럼에 저장됨.
현재 방식: event_params 배열 안에 {'key': 'user_id', 'value': {'string_value': '실제ID'}} 형태로 저장됨.

현재 user_id를 저장한 필드가 앱과 웹이 달라 탐색 비용 증가와 기능 사용 제한 등의 문제를 겪고 있습니다.
바쁘시겠지만, 데이터의 정확성과 활용도를 높이기 위해 꼭 필요한 작업입니다. 확인 후 수정 부탁 드립니다.
```