### PR TITLE
fix: 공지사항 리스트 버그 수정

### DIFF
--- a/Koin/Presentation/Home/HomeViewController.swift
+++ b/Koin/Presentation/Home/HomeViewController.swift
@@ -63,7 +63,6 @@ final class HomeViewController: UIViewController {
     
     private let noticePageControl = UIPageControl(frame: .zero).then {
         $0.currentPage = 0
-        $0.numberOfPages = 4
         $0.currentPageIndicatorTintColor = .appColor(.primary400)
         $0.pageIndicatorTintColor = .appColor(.neutral300)
     }
@@ -523,6 +522,7 @@ extension HomeViewController {
     
     private func updateHotArticles(articles: [NoticeArticleDTO], phrases: ((String, String), Int)?) {
         noticeListCollectionView.updateNoticeList(articles, phrases)
+        noticePageControl.numberOfPages = articles.count
     }
     
     private func putImage(data: ShopCategoryDTO) {
@@ -540,11 +540,9 @@ extension HomeViewController {
             goDiningPageButton.isHidden = false
         }
         else if result.variableName == .bannerNew {
-            noticePageControl.numberOfPages = 5
             inputSubject.send(.getNoticeBanner(Date()))
         }
         else {
-            noticePageControl.numberOfPages = 4
             inputSubject.send(.getNoticeBanner(nil))
         }
     }

--- a/Koin/Presentation/Home/SubViews/NoticeListCollectionView/NoticeListCollectionView.swift
+++ b/Koin/Presentation/Home/SubViews/NoticeListCollectionView/NoticeListCollectionView.swift
@@ -144,8 +144,7 @@ extension NoticeListCollectionView {
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: NoticeListCollectionViewCell.identifier, for: indexPath) as? NoticeListCollectionViewCell else {
                 return UICollectionViewCell()
             }
-            let newIndex = bannerCount == 5 ? indexPath.row - 1 : indexPath.row
-            let noticeArticleTitle = popularNoticeList[newIndex]
+            let noticeArticleTitle = popularNoticeList[indexPath.row - 1]
             cell.configure(title: noticeArticleTitle.title ?? "")
             return cell
         }


### PR DESCRIPTION
## #️⃣연관된 이슈

- #188  

## 📝작업 내용
1. pagecontrol 개수가 잘못 표시되고 있었음. 4개인데도 5개로 표시됨.
- API 요청 응답값으로 변경 
- 정적인 값(5개) 제거
2. 공지사항 리스트 값 index값 계산이 잘못 표시되고 있었음
- 가장 처음에 나오는 자취방 양도글?은 api 요청 응답이 아니라 직접 매핑해줘야 하는 페이지였던 걸로 추정.
- 그래서 응답값에 +1을 해주는 과정에서 뭔가 인덱싱이 꼬였던것같음. collectionview cell indexPath 조절했음.

## 추가
- 하지만 작업하면서 추가적인 버그 발견. 4번쨰 게시글까지 이동한 다음에 2초정도 뒤에 스와이프했을때 1번째 글로 안가고 다시 마지막거로 남아있는거로 보임.
- 그리고 stage에서는 공지사항 불러오는 api에서 응답값이 없어서 이것도 프로덕션으로 테스트 해야해요
