### PR TITLE
chore: eventList 클릭시 웹뷰 대신 네이티브로 push

### DIFF
--- a/Koin/Presentation/OrderHome/OrderHomeViewController.swift
+++ b/Koin/Presentation/OrderHome/OrderHomeViewController.swift
@@ -438,12 +438,27 @@ extension OrderHomeViewController {
         }
 
         eventOrderShopCollectionView.cellTapPublisher
-            .sink { [weak self] (shopId, _) in
+            .sink { [weak self] (orderableShopId, _) in
                 guard let self = self else { return }
-                let detailVC = OrderHomeDetailWebViewController(shopId: shopId, isFromOrder: true)
-                self.navigationController?.setNavigationBarHidden(true, animated: true)
-                self.navigationController?.pushViewController(detailVC, animated: true)
-                self.tabBarController?.tabBar.isHidden = true
+                let service = DefaultOrderService()
+                let repository = DefaultOrderShopRepository(service: service)
+                let fetchOrderShopSummaryUseCase = DefaultFetchOrderShopSummaryUseCase(repository: repository)
+                let fetchOrderShopMenusUseCase = DefaultFetchOrderShopMenusUseCase(repository: repository)
+                let fetchOrderShopMenusGroupsUseCase = DefaultFetchOrderShopMenusGroupsUseCase(repository: repository)
+                let fetchCartSummaryUseCase = DefaultFetchCartSummaryUseCase(repository: repository)
+                let fetchCartUseCase = DefaultFetchCartUseCase(repository: repository)
+                let fetchCartItemsCountUseCase = DefaultFetchCartItemsCountUseCase(repository: repository)
+                let resetCartUseCase = DefaultResetCartUseCase(repository: repository)
+                let viewModel = ShopDetailViewModel(fetchOrderShopSummaryUseCase: fetchOrderShopSummaryUseCase,
+                                                    fetchOrderShopMenusUseCase: fetchOrderShopMenusUseCase,
+                                                    fetchOrderShopMenusGroupsUseCase: fetchOrderShopMenusGroupsUseCase,
+                                                    fetchCartSummaryUseCase: fetchCartSummaryUseCase,
+                                                    fetchCartUseCase: fetchCartUseCase,
+                                                    fetchCartItemsCountUseCase: fetchCartItemsCountUseCase,
+                                                    resetCartUseCase: resetCartUseCase,
+                                                    orderableShopId: orderableShopId)
+                let viewController = ShopDetailViewController(viewModel: viewModel, isFromOrder: true)
+                navigationControllerDelegate?.pushViewController(viewController, animated: true)
             }
             .store(in: &subscriptions)
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

- #204 

## 📝작업 내용

orderhome 화면에서 eventListCollectionView를 탭했을 때,
웹뷰 대신 ShopDetailViewController로 진입하도록 변경했습니다.
기존 로직 복붙정도라서,, 바로 머지하겠습니다!