### PR TITLE
chore: 일부 주변상점 디코딩 실패 - dto 수정

### DIFF
--- a/Koin/Data/DTOs/Decodable/Shop/ShopSummaryDto.swift
+++ b/Koin/Data/DTOs/Decodable/Shop/ShopSummaryDto.swift
@@ -11,7 +11,8 @@ struct ShopSummaryDto: Decodable {
     let shopId: Int
     let name: String
     let introduction: String?
-    let ratingAverage, reviewCount: Int
+    let ratingAverage: Double
+    let reviewCount: Int
     let images: [ShopImageDto]
 
     enum CodingKeys: String, CodingKey {


### PR DESCRIPTION
## #️⃣연관된 이슈

- #253 

## 📝작업 내용

dto 에서 평점(ratingAverage)를 Int타입으로 잘못 만들어두어서, 평점이 4.7 과 같이 소수점인 일부 주변상점의 디코딩이 실패하고 있었습니다.
dto 에서 평점(ratingAverage)를 Int타입에서 Double타입으로 변경했습니다.