### PR TITLE
fix: 리뷰목록 QA 이슈 해결

### DIFF
--- a/Koin/Presentation/ShopReviewList/ReviewListViewController.swift
+++ b/Koin/Presentation/ShopReviewList/ReviewListViewController.swift
@@ -170,6 +170,8 @@ final class ReviewListViewController: UIViewController {
                     } else {
                         self.loadingIndicator.stopAnimating()
                     }
+                case .toggleMyReviewButton:
+                    reviewListCollectionView.toggleMyReviewButton()
                 }
             }
             .store(in: &cancellables)
@@ -179,11 +181,10 @@ final class ReviewListViewController: UIViewController {
         reviewListCollectionView.myReviewButtonPublisher
             .sink { [weak self] isMine in
                 guard let self else { return }
-                
                 if isMine {
-                    self.inputSubject.send(.checkLoginForMyReviewFilter)
-                } else {
                     self.inputSubject.send(.changeFilter(sorter: nil, isMine: false))
+                } else {
+                    self.inputSubject.send(.checkLoginForMyReviewFilter)
                 }
             }
             .store(in: &cancellables)

--- a/Koin/Presentation/ShopReviewList/ReviewListViewModel.swift
+++ b/Koin/Presentation/ShopReviewList/ReviewListViewModel.swift
@@ -78,6 +78,7 @@ final class ReviewListViewModel: ViewModelProtocol {
         )
         case setStatistics(StatisticsDto)
         case updateLoadingState(Bool)
+        case toggleMyReviewButton
     }
 
     // MARK: - Initialize
@@ -288,6 +289,7 @@ extension ReviewListViewModel {
                 
             case .myReviewFilter:
                 self.outputSubject.send(.applyMyReviewFilter)
+                self.outputSubject.send(.toggleMyReviewButton)
                 
             case .reportReview:
                 if let parameter {

--- a/Koin/Presentation/ShopReviewList/SubViews/ReviewListCollectionView/ReviewListCollectionView.swift
+++ b/Koin/Presentation/ShopReviewList/SubViews/ReviewListCollectionView/ReviewListCollectionView.swift
@@ -58,6 +58,15 @@ final class ReviewListCollectionView: UICollectionView {
 
 extension ReviewListCollectionView {
     
+    func toggleMyReviewButton() {
+        if let headerView = supplementaryView(
+            forElementKind: UICollectionView.elementKindSectionHeader,
+            at: IndexPath(item: 0, section: 0)
+        ) as? ReviewListHeaderView {
+            headerView.toggleMyReviewButton()
+        }
+    }
+    
     func addReviewList(_ list: [Review]) {
         reviewList.append(contentsOf: list)
         reloadData()

--- a/Koin/Presentation/ShopReviewList/SubViews/ReviewListCollectionView/ReviewListHeaderView.swift
+++ b/Koin/Presentation/ShopReviewList/SubViews/ReviewListCollectionView/ReviewListHeaderView.swift
@@ -72,6 +72,11 @@ extension ReviewListHeaderView {
 // MARK: - Button Configuration
 extension ReviewListHeaderView {
     
+    func toggleMyReviewButton() {
+        myReviewButton.isSelected.toggle()
+        configureMyReviewButton()
+    }
+    
     private func configureSortTypeButton(type: ReviewSortType) {
         var configuration = UIButton.Configuration.plain()
         
@@ -130,8 +135,6 @@ extension ReviewListHeaderView {
     }
     
     @objc private func myReviewButtonTapped() {
-        myReviewButton.isSelected.toggle()
-        configureMyReviewButton()
         myReviewButtonPublisher.send(myReviewButton.isSelected)
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

- #269 

## 📝작업 내용

1. 로그인 상태 확인 로직 개선
- 기존 로직에서는 fetchUserDataUseCase를 호출하여, receivedCompletion 에서 fail일 경우 로그아웃 상태, receiveValue 에서 로그인 상태로 판단합니다. 
- receiveValue에서 받은 userData를 사용하지 않으므로, UseCase를 삭제하고 UserDataManager.shared.userId.isEmpty 를 확인하도록 변경했습니다.

2. '내가 작성한 리뷰 보기'
- 기존 로직에서는 버튼을 누를 경우, 버튼 상태를 바꾼 후, 로그인 상태를 판단합니다.
- 변경된 로직에서는 버튼을 누를 경우, 로그인 상태를 판단합니다. 로그인된 상태일 경우 버튼 상태를 바꿉니다. 
- 로그아웃 상태일 경우, 버튼을 눌러도 반응이 없습니다.

### 스크린샷 (선택)

- 로그인 상태
![ezgif-65f3d970b7f84bc5](https://github.com/user-attachments/assets/65a3b143-c059-4291-a087-df1559311496)

- 로그아웃 상태
![ezgif-6b3270c310b5ef7c](https://github.com/user-attachments/assets/f403d2c6-bfd1-46de-be42-8e823c2ce4f8)



## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
