### PR TITLE
fix: 필터적용시 상점이 비었을경우 EmptyView추가

### DIFF
--- a/Koin/Presentation/Shop/ShopViewController.swift
+++ b/Koin/Presentation/Shop/ShopViewController.swift
@@ -497,7 +497,6 @@ extension ShopViewController {
             $0.leading.equalToSuperview().offset(24)
             $0.trailing.equalToSuperview().offset(-24)
             $0.height.equalTo(1)
-//            $0.bottom.equalToSuperview().offset(-32)
         }
         emptyResultStackView.snp.makeConstraints {
             $0.centerY.equalTo(view.safeAreaLayoutGuide)
@@ -505,7 +504,6 @@ extension ShopViewController {
             $0.leading.trailing.equalToSuperview().inset(24)
             $0.bottom.equalToSuperview().offset(-32)
         }
-
     }
     
     private func configureView() {


### PR DESCRIPTION
## #️⃣연관된 이슈

> - #288 

## 📝작업 내용

>orderHomeVC에선 처리가 되있는데 shopVC에서 emptyView처리가 안되있어서 추가했습니다! 

### 스크린샷 (선택)
<img width="568" height="1084" alt="image" src="https://github.com/user-attachments/assets/f82712d2-b8d6-49f4-a54c-bf9bcdbf5b3f" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
