### PR TITLE
chore: ShopSearch에서 pushViewController하기 전에 title 설정

### DIFF
--- a/Koin/Presentation/ShopSearch/ShopSearchViewController.swift
+++ b/Koin/Presentation/ShopSearch/ShopSearchViewController.swift
@@ -171,6 +171,7 @@ extension ShopSearchViewController {
                                              shopId: shopId,
                                              shopName: shopName)
         let viewController = ShopSummaryViewController(viewModel: viewModel)
+        viewController.title = shopName
         navigationController?.pushViewController(viewController, animated: true)
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

- #292 

## 📝작업 내용

상점검색페이지에서 검색을 통해 상점정보 페이지 진입시, title이 설정되지 않았습니다.
title 설정을 추가했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
