### PR TITLE
fix: Interceptor 토큰 갱신 실패시 로직 수정

### DIFF
--- a/Koin/Data/Service/Network/Interceptor.swift
+++ b/Koin/Data/Service/Network/Interceptor.swift
@@ -20,7 +20,7 @@ final class Interceptor: RequestInterceptor {
     private var refreshSubscription: AnyCancellable?
     
     private var adaptRequests: [(urlRequest: URLRequest, completion: (Result<URLRequest, any Error>) -> Void)] = []
-    private var retryRequests: [(error: Error, completion: @Sendable (RetryResult) -> Void)] = []
+    private var retryRequests: [@Sendable (RetryResult) -> Void] = []
     
     // MARK: - Adapt
     func adapt(_ urlRequest: URLRequest,
@@ -46,14 +46,14 @@ final class Interceptor: RequestInterceptor {
         
         guard let responseCode = request.response?.statusCode,
               responseCode == 401 else {
-            completion(.doNotRetryWithError(error))
+            completion(.doNotRetry)
             return
         }
         guard request.retryCount < retryLimit,
               let _ = KeychainWorker.shared.read(key: .refresh) else {
             KeychainWorker.shared.delete(key: .access)
             KeychainWorker.shared.delete(key: .refresh)
-            completion(.doNotRetryWithError(error))
+            completion(.doNotRetry)
             return
         }
         
@@ -61,11 +61,11 @@ final class Interceptor: RequestInterceptor {
         defer {
             lock.unlock()
         }
-        retryRequests.append((error: error, completion: completion))
+        retryRequests.append(completion)
         
         if !isRefreshing {
             self.isRefreshing = true
-            refreshSubscription = refreshToken().sink { [weak self] shouldRetry in
+            refreshSubscription = refreshToken().sink { [weak self] in
                 guard let self else { return }
                 
                 self.lock.lock()
@@ -76,11 +76,11 @@ final class Interceptor: RequestInterceptor {
                 self.isRefreshing = false
                 self.lock.unlock()
                 
-                adaptRequests.forEach {
-                    self.adapt(urlRequest: $0.urlRequest, completion: $0.completion)
+                adaptRequests.forEach { [weak self] in
+                    self?.adapt(urlRequest: $0.urlRequest, completion: $0.completion)
                 }
-                retryRequests.forEach {
-                    self.retry(error: $0.error, completion: $0.completion, shouldRetry: shouldRetry)
+                retryRequests.forEach { [weak self] in
+                    self?.retry(completion: $0)
                 }
             }
         }
@@ -98,29 +98,24 @@ extension Interceptor {
         completion(.success(urlRequest))
     }
     
-    private func retry(error: Error, completion: @escaping @Sendable (RetryResult) -> Void, shouldRetry: Bool) {
-        
-        if shouldRetry {
-            completion(.retry)
-        } else {
-            completion(.doNotRetryWithError(error))
-        }
+    private func retry(completion: @escaping @Sendable (RetryResult) -> Void) {
+        completion(.retry)
     }
 }
 
 extension Interceptor {
     
-    private func refreshToken() -> AnyPublisher<Bool, Never> {
+    private func refreshToken() -> AnyPublisher<Void, Never> {
         return requestWithResponse(api: UserAPI.refreshToken(RefreshTokenRequest(refreshToken: KeychainWorker.shared.read(key: .refresh) ?? "")))
             .map { (tokenDto: TokenDto) in
                 KeychainWorker.shared.create(key: .access, token: tokenDto.token)
                 KeychainWorker.shared.create(key: .refresh, token: tokenDto.refreshToken)
-                return true
+                return
             }
-            .catch { _ -> Just<Bool> in
+            .catch { _ -> Just<Void> in
                 KeychainWorker.shared.delete(key: .access)
                 KeychainWorker.shared.delete(key: .refresh)
-                return Just(false)
+                return Just(Void())
             }
             .eraseToAnyPublisher()
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

- #388 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- refresh token이 만료되어서 토큰 갱신 실패시 공개 API가 실패함을 방지하기 위해, 토큰 갱신 성공여부와 무관하게 retry하도록 변경했습니다. 
- 불필요한 doNotRetryWithError를 doNotRetry로 변경했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified network request retry coordination by optimizing error handling flow to enhance code efficiency and maintainability. No changes to user-facing retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->