### PR TITLE
fix: 콜밴팟 채팅 순서 오류 수정, UI 사소한 개선

### DIFF
--- a/Koin/Data/DTOs/Decodable/CallVan/CallVanChatDto.swift
+++ b/Koin/Data/DTOs/Decodable/CallVan/CallVanChatDto.swift
@@ -130,8 +130,8 @@ extension CallVanChatDto {
         }
         return CallVanChat(
             roomName: roomName,
-            dates: sortedDates,
-            messages: sectionMessages.map { $0.reversed() }
+            dates: sortedDates.reversed(),
+            messages: sectionMessages.map { $0.reversed() }.reversed()
         )
     }
 }

--- a/Koin/Presentation/CallVan/CallVanChat/CallVanChatViewController.swift
+++ b/Koin/Presentation/CallVan/CallVanChat/CallVanChatViewController.swift
@@ -49,6 +49,7 @@ final class CallVanChatViewController: UIViewController {
         setDelegate()
         setAddTargets()
         bind()
+        setGesture()
         configureNavigationBar(style: .empty)
         inputSubject.send(.viewDidLoad)
     }
@@ -88,9 +89,19 @@ final class CallVanChatViewController: UIViewController {
 
 extension CallVanChatViewController {
     
+    private func setGesture() {
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(didTapAround))
+        tapGesture.cancelsTouchesInView = false
+        callVanChatTableView.addGestureRecognizer(tapGesture)
+    }
+    
     private func setAddTargets() {
         sendImageButton.addTarget(self, action: #selector(sendImageButtonTapped), for: .touchUpInside)
         sendMessageButton.addTarget(self, action: #selector(sendMessageButtonTapped), for: .touchUpInside)
+    }
+    
+    @objc private func didTapAround() {
+        dismissKeyboard()
     }
     
     @objc private func sendMessageButtonTapped() {

--- a/Koin/Presentation/CallVan/CallVanChat/Subviews/CallVanChatTableView/CallVanChatLeftCell.swift
+++ b/Koin/Presentation/CallVan/CallVanChat/Subviews/CallVanChatTableView/CallVanChatLeftCell.swift
@@ -139,6 +139,9 @@ extension CallVanChatLeftCell {
         messageImageView.do {
             $0.backgroundColor = UIColor.appColor(.neutral100)
             $0.isUserInteractionEnabled = true
+            $0.contentMode = .scaleAspectFill
+            $0.clipsToBounds = true
+            $0.layer.cornerRadius = 12
         }
         messageImageTimeLabel.do {
             $0.font = UIFont.appFont(.pretendardRegular, size: 12)

--- a/Koin/Presentation/CallVan/CallVanChat/Subviews/CallVanChatTableView/CallVanChatRightCell.swift
+++ b/Koin/Presentation/CallVan/CallVanChat/Subviews/CallVanChatTableView/CallVanChatRightCell.swift
@@ -122,6 +122,9 @@ extension CallVanChatRightCell {
         messageImageView.do {
             $0.backgroundColor = UIColor.appColor(.neutral100)
             $0.isUserInteractionEnabled = true
+            $0.contentMode = .scaleAspectFill
+            $0.clipsToBounds = true
+            $0.layer.cornerRadius = 12
         }
         messageImageTimeLabel.do {
             $0.font = UIFont.appFont(.pretendardRegular, size: 12)


### PR DESCRIPTION
## #️⃣연관된 이슈

- #390 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

채팅 순서가 뒤집기 위해 dto의 toDomain 메서드에서 reverse를 추가했습니다. 
imageView의 비율, 반경을 수정했습니다.
키보드 닫힘 제스처를 개선했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Keyboard now dismisses when tapping outside the chat input field, streamlining conversation navigation.

## Style
- Message images enhanced with rounded corners and optimized scaling for improved visual consistency throughout the chat interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->