### PR TITLE
delete: A/B Test 관련 로깅 case 삭제

### DIFF
--- a/Koin/Core/Logger/EventParameter.swift
+++ b/Koin/Core/Logger/EventParameter.swift
@@ -25,17 +25,11 @@ enum EventParameter {
             }
         }
         
-        enum AbTest: String, EventLabelType {
-            case businessBenefit = "BUSINESS_benefit_1"
-            case businessCall = "BUSINESS_call_1"
-            case campusClub1 = "CAMPUS_club_1"
-            case dining2shop1 = "dining2shop_1"
-            case diningToShop = "dining_to_shop"
-            case diningToShopClose = "dining_to_shop_close"
-            var team: String {
-                return "AB_TEST"
-            }
-        }
+//        enum AbTest: String, EventLabelType {
+//            var team: String {
+//                return "AB_TEST"
+//            }
+//        }
         
         enum Business: String, EventLabelType {
             // Shop
@@ -95,6 +89,7 @@ enum EventParameter {
             case menuShare = "menu_share"
             case cafeteriaInfo = "cafeteria_info"
             case notificationMenuImageUpload = "notification_menu_image_upload"
+            case diningToShop = "dining_to_shop"
             
             // Bus
             case errorFeedbackButton = "error_feedback_button"
@@ -241,11 +236,6 @@ enum EventParameter {
         case swipe
         case signup
         case entry
-        case abTestBenefit = "a/b test 로깅(3차 스프린트, 혜택페이지)"
-        case abTestDining = "a/b test 로깅(식단 메인 진입점)"
-        case abTestKeyword = "a/b test 로깅(키워드 알림 배너)"
-        case abTestCall = "a/b test 로깅(전화하기)"
-        case abTestDiningEntry = "a/b test 로깅(메인화면 식단 진입)"
         case pageView = "page_view"
         case pageExit = "page_exit"
         case update = "update"


### PR DESCRIPTION
## #️⃣연관된 이슈

- #404

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

A/B 테스트 로깅 제거 작업입니다.

- `dining2shop_1`: 아하 모먼트 A/B 테스트
- `CAMPUS_notice_1`: 키워드 관리 진입 배너
- `CAMPUS_modal_1`: 모달 디자인
- `CAMPUS_dining_1`: 식단 메인 진입점
- `CAMPUS_club_1`: 동아리 디자인
- `BUSINESS_call_1`: 전화하기
- `BUSINESS_benefit_1`: 혜택

위 event_label 중 실제 로깅중인 로직은 존재하지 않았습니다.
EventParameter 에서 삭제했습니다.

dining_to_shop 을 AB_Test에서 CAMPUS로 이동했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요