### PR TITLE
refactor, fix: 화면 종료시 click 또는 swipe 선별 로깅 - 오류 수정 & Protocol 정의  #440

### DIFF
--- a/Koin/Core/Protocol/PopLoggable.swift
+++ b/Koin/Core/Protocol/PopLoggable.swift
@@ -1,0 +1,12 @@
+//
+//  PopLoggable.swift
+//  koin
+//
+//  Created by 홍기정 on 5/31/26.
+//
+
+import UIKit
+
+protocol PopLoggable where Self: UIViewController {
+    func sendPopLog(category: EventParameter.EventCategory)
+}

--- a/Koin/Core/View/CustomNavigationController.swift
+++ b/Koin/Core/View/CustomNavigationController.swift
@@ -7,19 +7,14 @@
 
 import UIKit
 
-class CustomNavigationController: UINavigationController, UIGestureRecognizerDelegate, UINavigationControllerDelegate {
-    
-    var didSwipeToPop = false
+final class CustomNavigationController: UINavigationController, UIGestureRecognizerDelegate, UINavigationControllerDelegate {
     
     override func viewDidLoad() {
         super.viewDidLoad()
         self.delegate = self
-        interactivePopGestureRecognizer?.addTarget(self, action: #selector(didRecognizePopGesture))
     }
     
     func navigationController(_ navigationController: UINavigationController, didShow viewController: UIViewController, animated: Bool) {
-        didSwipeToPop = false
-        
         guard let interactivePopGestureRecognizer = self.interactivePopGestureRecognizer else { return }
         if viewControllers.count > 1 {
             interactivePopGestureRecognizer.isEnabled = true
@@ -29,23 +24,26 @@ class CustomNavigationController: UINavigationController, UIGestureRecognizerDel
     }
     
     func navigationController(_ navigationController: UINavigationController, willShow viewController: UIViewController, animated: Bool) {
-        navigationController.transitionCoordinator?.notifyWhenInteractionChanges { [weak self] context in
-            if context.isCancelled {
-                self?.didSwipeToPop = false
+        guard let transitionCoordinator = navigationController.transitionCoordinator,
+              let fromVC = transitionCoordinator.viewController(forKey: .from),
+              let toVC = transitionCoordinator.viewController(forKey: .to) else {
+            return
+        }
+        let isPop = navigationController.viewControllers.contains(toVC)
+        let isSwipe = transitionCoordinator.isInteractive
+        
+        if isPop, let loggableVC = fromVC as? PopLoggable {
+            transitionCoordinator.animate(alongsideTransition: nil) { _ in
+                // 사용자가 스와이프를 취소하지 않고 화면이 완전히 사라졌을 때만 실행
+                if !transitionCoordinator.isCancelled {
+                    let category: EventParameter.EventCategory = isSwipe ? .swipe : .click
+                    loggableVC.sendPopLog(category: category)
+                }
             }
         }
     }
 
     override var childForStatusBarStyle: UIViewController? {
         return topViewController
-    }
-    
-    @objc private func didRecognizePopGesture() {
-        switch interactivePopGestureRecognizer?.state {
-        case .began:
-            didSwipeToPop = true
-        default:
-            break
-        }
     }
 }

--- a/Koin/Presentation/CallVan/CallVanList/CallVanListViewController.swift
+++ b/Koin/Presentation/CallVan/CallVanList/CallVanListViewController.swift
@@ -14,7 +14,6 @@ final class CallVanListViewController: UIViewController {
     private let viewModel: CallVanListViewModel
     private let inputSubject = PassthroughSubject<CallVanListViewModel.Input, Never>()
     private var subscriptions: Set<AnyCancellable> = []
-    private var didSwipeToPop = false
     private var hasShownNotificationBottomSheet = false
     
     // MARK: - UI Components
@@ -56,21 +55,6 @@ final class CallVanListViewController: UIViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         checkNotification()
-    }
-    
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-        if let didSwipeToPop = (navigationController as? CustomNavigationController)?.didSwipeToPop {
-            self.didSwipeToPop = didSwipeToPop
-        }
-    }
-    
-    override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
-        if isMovingFromParent {
-            let category: EventParameter.EventCategory = didSwipeToPop ? .swipe : .click
-            inputSubject.send(.logEvent(label: EventParameter.EventLabel.Campus.callvanBack, category: category, value: ""))
-        }
     }
     
     private func bind() {
@@ -119,6 +103,12 @@ final class CallVanListViewController: UIViewController {
         callVanListCollectionView.didScrollPublisher.receive(on: DispatchQueue.main).sink { [weak self] in
             self?.dismissKeyboard()
         }.store(in: &subscriptions)
+    }
+}
+
+extension CallVanListViewController: PopLoggable {
+    func sendPopLog(category: EventParameter.EventCategory) {
+        inputSubject.send(.logEvent(label: EventParameter.EventLabel.Campus.callvanBack, category: category, value: ""))
     }
 }
 

--- a/Koin/Presentation/CallVan/CallVanPost/CallVanPostViewController.swift
+++ b/Koin/Presentation/CallVan/CallVanPost/CallVanPostViewController.swift
@@ -21,7 +21,6 @@ final class CallVanPostViewController: UIViewController {
     private let inputSubject = PassthroughSubject<CallVanPostViewModel.Input, Never>()
     private let viewModel: CallVanPostViewModel
     private var subscriptions: Set<AnyCancellable> = []
-    private var didSwipeToPop = false
     
     // MARK: - UI Components
     private let placeView = CallVanPostPlaceView()
@@ -61,21 +60,6 @@ final class CallVanPostViewController: UIViewController {
         bind()
         dateView.update(Date())
         timeView.update(Date())
-    }
-    
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-        if let didSwipeToPop = (navigationController as? CustomNavigationController)?.didSwipeToPop {
-            self.didSwipeToPop = didSwipeToPop
-        }
-    }
-    
-    override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
-        if isMovingFromParent {
-            let category: EventParameter.EventCategory = didSwipeToPop ? .swipe : .click
-            inputSubject.send(.logEvent(label: EventParameter.EventLabel.Campus.callvanWriteBack, category: category, value: ""))
-        }
     }
     
     private func bind() {
@@ -145,6 +129,12 @@ final class CallVanPostViewController: UIViewController {
         participantsView.participantsChangedPublisher.sink { [weak self] participants in
             self?.inputSubject.send(.updateMaxParticipants(participants))
         }.store(in: &subscriptions)
+    }
+}
+
+extension CallVanPostViewController: PopLoggable {
+    func sendPopLog(category: EventParameter.EventCategory) {
+        inputSubject.send(.logEvent(label: EventParameter.EventLabel.Campus.callvanWriteBack, category: category, value: ""))
     }
 }
 

--- a/Koin/Presentation/Shop/ShopBenefit/ShopBenefitViewController.swift
+++ b/Koin/Presentation/Shop/ShopBenefit/ShopBenefitViewController.swift
@@ -16,7 +16,6 @@ final class ShopBenefitViewController: UIViewController {
     private let inputSubject = PassthroughSubject<ShopBenefitViewModel.Input, Never>()
     private var subscriptions: Set<AnyCancellable> = []
     private let viewModel: ShopBenefitViewModel
-    private var didSwipeToPop = false
     
     // MARK: - UI Components
     private let benefitsTableView = ShopBenefitTableView()
@@ -66,22 +65,11 @@ final class ShopBenefitViewController: UIViewController {
             self.inputSubject.send(.logEvent(EventParameter.EventLabel.Business.shopBenefitDetail, EventParameter.EventCategory.click, self.viewModel.shopName))
         }.store(in: &subscriptions)
     }
+}
 
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-        if let didSwipeToPop = (navigationController as? CustomNavigationController)?.didSwipeToPop {
-            self.didSwipeToPop = didSwipeToPop
-        }
-    }
-
-    override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
-        
-        if isMovingFromParent || isBeingDismissed {
-            let category: EventParameter.EventCategory = didSwipeToPop ? .swipe : .click
-            
-            inputSubject.send(.logEvent(EventParameter.EventLabel.Business.shopBenefitBack, category, viewModel.shopName))
-        }
+extension ShopBenefitViewController: PopLoggable {
+    func sendPopLog(category: EventParameter.EventCategory) {
+        inputSubject.send(.logEvent(EventParameter.EventLabel.Business.shopBenefitBack, category, viewModel.shopName))
     }
 }
 

--- a/koin.xcodeproj/project.pbxproj
+++ b/koin.xcodeproj/project.pbxproj
@@ -119,6 +119,7 @@
 		7C61D35B2F23CF1A005FAC3A /* FetchLostItemStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C61D35A2F23CF1A005FAC3A /* FetchLostItemStats.swift */; };
 		7C61D35F2F24000C005FAC3A /* LostItemDataButtonsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C61D35E2F24000C005FAC3A /* LostItemDataButtonsView.swift */; };
 		7C61D3632F242D8D005FAC3A /* AddLostItemHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C61D3622F242D8D005FAC3A /* AddLostItemHeaderView.swift */; };
+		7C6790322FCC00150045E163 /* PopLoggable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C6790312FCC00150045E163 /* PopLoggable.swift */; };
 		7C7CCE4A2F834D4B00E3A54B /* CallVanModalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C7CCE492F834D4B00E3A54B /* CallVanModalViewController.swift */; };
 		7C7CCE702F866E9400E3A54B /* AppPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C7CCE6F2F866E9400E3A54B /* AppPath.swift */; };
 		7C7CCE722F86863200E3A54B /* FetchCallVanRestrictionUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C7CCE712F86863200E3A54B /* FetchCallVanRestrictionUseCase.swift */; };
@@ -1043,6 +1044,7 @@
 		7C61D35A2F23CF1A005FAC3A /* FetchLostItemStats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchLostItemStats.swift; sourceTree = "<group>"; };
 		7C61D35E2F24000C005FAC3A /* LostItemDataButtonsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LostItemDataButtonsView.swift; sourceTree = "<group>"; };
 		7C61D3622F242D8D005FAC3A /* AddLostItemHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddLostItemHeaderView.swift; sourceTree = "<group>"; };
+		7C6790312FCC00150045E163 /* PopLoggable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopLoggable.swift; sourceTree = "<group>"; };
 		7C7CCE492F834D4B00E3A54B /* CallVanModalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallVanModalViewController.swift; sourceTree = "<group>"; };
 		7C7CCE6F2F866E9400E3A54B /* AppPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppPath.swift; sourceTree = "<group>"; };
 		7C7CCE712F86863200E3A54B /* FetchCallVanRestrictionUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchCallVanRestrictionUseCase.swift; sourceTree = "<group>"; };
@@ -4373,6 +4375,7 @@
 				D27DD0822BA608310081FD36 /* CollectionViewDelegate.swift */,
 				D8F5C54B2E6F012500FB6708 /* LottieAnimationManageable.swift */,
 				7CED923A2EF2D26000457128 /* Coordinator.swift */,
+				7C6790312FCC00150045E163 /* PopLoggable.swift */,
 			);
 			path = Protocol;
 			sourceTree = "<group>";
@@ -5970,6 +5973,7 @@
 				7C61D33E2F21FADF005FAC3A /* EditLostItemViewController.swift in Sources */,
 				D20AD7052E0367E00067760A /* ResetPasswordSmsRequest.swift in Sources */,
 				831ABDC42CA29A120099B70C /* NoticeKeywordsFetchResult.swift in Sources */,
+				7C6790322FCC00150045E163 /* PopLoggable.swift in Sources */,
 				D249CD2C2C12E32F000813F9 /* DefaultDiningRepository.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
## #️⃣연관된 이슈

- #440 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

화면 종료시 (viewController를 pop할때) let isSwipe = navigationController?.transitionCoordinator?.isInteractive ?? false 방식으로 click 또는 swipe를 선별하여 로깅할 때, 항상 click으로 로깅되는 오류를 수정합니다.

- ViewController의 Pop을 감지하고, click 인지 swipe 인지 구별하는 역할을 CustomNavigationController에 집중시켰습니다.
- click 또는 swipe를 선별하여 로깅해야하는 ViewController가 채택해야하는 PopLoggable 프로토콜을 정의했습니다.
- CustomNavigationController는 popVC가 PopLoggable으로 캐스팅 가능한 경우 로깅을 지시합니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated back-navigation event tracking: navigation now uses transition-based logic to detect pop events and logs them according to interaction type (swipe versus click), replacing previous gesture-based tracking.
  * Centralized pop-logging behavior across screens through a new internal protocol, enabling consistent event handling throughout the application's navigation flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->