### PR TITLE
feat, fix, refactor: 홈화면 식단 시간 API 연결, 비로그인 상태에서 데이터 호출 실패 버그 수정, 식단 카드 뷰 로직 개선

### DIFF
--- a/Koin/Apps/SceneDelegate.swift
+++ b/Koin/Apps/SceneDelegate.swift
@@ -208,6 +208,7 @@ extension SceneDelegate {
         let fetchHomeHeaderUseCase = DefaultFetchHomeHeaderUseCase(homeRepository: homeRepository, userRepository: userRepository)
         let fetchHomeDiningListUseCase = DefaultFetchHomeDiningListUseCase(
             fetchDiningListUseCase: DefaultFetchDiningListUseCase(diningRepository: diningRepository),
+            fetchCoopShopListUseCase: DefaultFetchCoopShopListUseCase(diningRepository: diningRepository),
             dateProvider: DefaultDateProvider()
         )
         let fetchCountsUseCase = DefaultFetchNewHomeCountsUseCase(

--- a/Koin/Core/Extensions/Common/String+byCharWrapping.swift
+++ b/Koin/Core/Extensions/Common/String+byCharWrapping.swift
@@ -1,0 +1,16 @@
+//
+//  String+byCharWrapping.swift
+//  koin
+//
+//  Created by 홍기정 on 6/7/26.
+//
+
+import Foundation
+
+/// 문자열 글자 사이사이에 Zero Width Space를 삽입합니다.
+/// SwiftUI Text가 lineBreakMode(.byCharWrapping) 처럼 동작하도록 합니다.
+extension String {
+    var byCharWrapping: String {
+        self.map { String($0) }.joined(separator: "\u{200B}")
+    }
+}

--- a/Koin/Data/DTOs/Decodable/Dining/DiningDto.swift
+++ b/Koin/Data/DTOs/Decodable/Dining/DiningDto.swift
@@ -73,16 +73,3 @@ enum DiningPlace: String, Decodable {
         self = DiningPlace(rawValue: rawValue) ?? .cornerA
     }
 }
-
-extension DiningType {
-    var newHomeDiningTimeText: String {
-        switch self {
-        case .breakfast:
-            return "08:30 – 09:30"
-        case .lunch:
-            return "11:30 – 13:30"
-        case .dinner:
-            return "17:30 – 18:30"
-        }
-    }
-}

--- a/Koin/Data/Service/UserService.swift
+++ b/Koin/Data/Service/UserService.swift
@@ -67,6 +67,11 @@ final class DefaultUserService: UserService {
     }
     
     func checkLogin() -> AnyPublisher<Bool, Never> {
+        guard let accessToken = KeychainWorker.shared.read(key: .access),
+              !accessToken.isEmpty else {
+            return Just(false).eraseToAnyPublisher()
+        }
+
         return (networkService.request(api: UserAPI.checkLogin) as AnyPublisher<Void, ErrorResponse>)
             .map { _ in true }
             .replaceError(with: false)

--- a/Koin/Domain/Model/NewHome/HomeDiningItem.swift
+++ b/Koin/Domain/Model/NewHome/HomeDiningItem.swift
@@ -13,7 +13,7 @@ struct HomeDiningItem: Equatable, Identifiable {
     let timeText: String
     let priceText: String?
     let kcalText: String?
-    let menu: [String]
+    let menu: String
 }
 
 extension HomeDiningItem {
@@ -24,7 +24,7 @@ extension HomeDiningItem {
             timeText: diningItem.type.newHomeDiningTimeText,
             priceText: diningItem.newHomeDiningPriceText,
             kcalText: "\(diningItem.kcal)kcal",
-            menu: diningItem.menu
+            menu: diningItem.menu.joined(separator: " · ")
         )
     }
 }

--- a/Koin/Domain/Model/NewHome/HomeDiningItem.swift
+++ b/Koin/Domain/Model/NewHome/HomeDiningItem.swift
@@ -10,18 +10,18 @@ import Foundation
 struct HomeDiningItem: Equatable, Identifiable {
     let id: Int
     let placeName: String
-    let timeText: String
+    let timeText: String?
     let priceText: String?
     let kcalText: String?
     let menu: String
 }
 
 extension HomeDiningItem {
-    init(_ diningItem: DiningItem) {
+    init(_ diningItem: DiningItem, timeText: String?) {
         self.init(
             id: diningItem.id,
             placeName: diningItem.place.rawValue,
-            timeText: diningItem.type.newHomeDiningTimeText,
+            timeText: timeText,
             priceText: diningItem.newHomeDiningPriceText,
             kcalText: "\(diningItem.kcal)kcal",
             menu: diningItem.menu.joined(separator: " · ")

--- a/Koin/Domain/Model/NewHome/HomeHeader.swift
+++ b/Koin/Domain/Model/NewHome/HomeHeader.swift
@@ -10,7 +10,7 @@ import Foundation
 struct HomeHeader: Equatable {
     let dateText: String
     let weather: Weather
-    let userName: String
+    let userName: String?
     let message: String
 }
 
@@ -22,6 +22,6 @@ struct Weather: Equatable {
 
 extension HomeHeader {
     static func empty() -> HomeHeader {
-        return HomeHeader(dateText: "", weather: Weather(temperature: 0, weatherText: "", imageUrl: ""), userName: "", message: "")
+        return HomeHeader(dateText: "", weather: Weather(temperature: 0, weatherText: "", imageUrl: ""), userName: nil, message: "")
     }
 }

--- a/Koin/Domain/UseCase/NewHome/FetchHomeDiningListUseCase.swift
+++ b/Koin/Domain/UseCase/NewHome/FetchHomeDiningListUseCase.swift
@@ -28,6 +28,7 @@ final class DefaultFetchHomeDiningListUseCase: FetchHomeDiningListUseCase {
             .map { diningItems in
                 diningItems
                     .map(HomeDiningItem.init)
+                    .filter { $0.placeName != "2캠퍼스" }
             }
             .eraseToAnyPublisher()
     }

--- a/Koin/Domain/UseCase/NewHome/FetchHomeDiningListUseCase.swift
+++ b/Koin/Domain/UseCase/NewHome/FetchHomeDiningListUseCase.swift
@@ -14,22 +14,68 @@ protocol FetchHomeDiningListUseCase {
 
 final class DefaultFetchHomeDiningListUseCase: FetchHomeDiningListUseCase {
     private let fetchDiningListUseCase: FetchDiningListUseCase
+    private let fetchCoopShopListUseCase: FetchCoopShopListUseCase
     private let dateProvider: DateProvider
 
-    init(fetchDiningListUseCase: FetchDiningListUseCase, dateProvider: DateProvider) {
+    init(
+        fetchDiningListUseCase: FetchDiningListUseCase,
+        fetchCoopShopListUseCase: FetchCoopShopListUseCase,
+        dateProvider: DateProvider
+    ) {
         self.fetchDiningListUseCase = fetchDiningListUseCase
+        self.fetchCoopShopListUseCase = fetchCoopShopListUseCase
         self.dateProvider = dateProvider
     }
 
     func execute() -> AnyPublisher<[HomeDiningItem], ErrorResponse> {
         let dateInfo = dateProvider.execute(date: Date())
-
+        
         return fetchDiningListUseCase.execute(diningInfo: dateInfo)
-            .map { diningItems in
-                diningItems
-                    .map(HomeDiningItem.init)
+            .zip(fetchCoopShopListUseCase.execute())
+            .map { (diningItems, coopShopData) in
+                let weekdayOperatingTimes = self.weekdayOperatingTimes(from: coopShopData)
+
+                return diningItems
+                    .map {
+                        HomeDiningItem(
+                            $0,
+                            timeText: weekdayOperatingTimes[$0.type]
+                        )
+                    }
                     .filter { $0.placeName != "2캠퍼스" }
             }
             .eraseToAnyPublisher()
+    }
+}
+
+extension DefaultFetchHomeDiningListUseCase {
+    private func weekdayOperatingTimes(from coopShopData: CoopShopData) -> [DiningType: String] {
+        coopShopData.opens
+            .filter { $0.dayOfWeek == .weekday }
+            .reduce(into: [:]) { result, open in
+                guard let diningType = DiningType(mealType: open.type) else { return }
+                
+                if open.openTime != "미운영",
+                   open.closeTime != "미운영",
+                   !open.openTime.isEmpty,
+                   !open.closeTime.isEmpty {
+                    result[diningType] = "\(open.openTime) - \(open.closeTime)"
+                } else {
+                    result[diningType] = nil
+                }
+            }
+    }
+}
+
+private extension DiningType {
+    init?(mealType: MealType) {
+        switch mealType {
+        case .breakfast:
+            self = .breakfast
+        case .lunch:
+            self = .lunch
+        case .dinner:
+            self = .dinner
+        }
     }
 }

--- a/Koin/Domain/UseCase/NewHome/FetchHomeHeaderUseCase.swift
+++ b/Koin/Domain/UseCase/NewHome/FetchHomeHeaderUseCase.swift
@@ -26,13 +26,17 @@ final class DefaultFetchHomeHeaderUseCase: FetchHomeHeaderUseCase {
         let dateText = dateText(from: Date())
         let message = "오늘도 잘 챙겨먹어요"
         
-        return homeRepository.fetchWeather()
-            .zip(userRepository.fetchUserData())
+        let weather = homeRepository.fetchWeather()
+        let userDto = userRepository.fetchUserData()
+            .map(Optional.some)
+            .catch { _ in Just(nil).setFailureType(to: ErrorResponse.self) }
+        
+        return weather.zip(userDto)
             .map { (weather, userDto) in
                 HomeHeader(
                     dateText: dateText,
                     weather: weather,
-                    userName: userDto.nickname ?? userDto.name ?? "익명",
+                    userName: userDto?.nickname ?? userDto?.name,
                     message: message
                 )
             }

--- a/Koin/Presentation/Home/Home/SubViews/ForceModifyUserViewController.swift
+++ b/Koin/Presentation/Home/Home/SubViews/ForceModifyUserViewController.swift
@@ -113,6 +113,7 @@ extension ForceModifyUserViewController {
         let fetchHomeHeaderUseCase = DefaultFetchHomeHeaderUseCase(homeRepository: homeRepository, userRepository: userRepository)
         let fetchHomeDiningListUseCase = DefaultFetchHomeDiningListUseCase(
             fetchDiningListUseCase: DefaultFetchDiningListUseCase(diningRepository: diningRepository),
+            fetchCoopShopListUseCase: DefaultFetchCoopShopListUseCase(diningRepository: diningRepository),
             dateProvider: DefaultDateProvider()
         )
         let fetchCountsUseCase = DefaultFetchNewHomeCountsUseCase(

--- a/Koin/Presentation/Login/FindId/ViewControllers/FoundIdViewController.swift
+++ b/Koin/Presentation/Login/FindId/ViewControllers/FoundIdViewController.swift
@@ -148,6 +148,7 @@ extension FoundIdViewController {
         let fetchHomeHeaderUseCase = DefaultFetchHomeHeaderUseCase(homeRepository: homeRepository, userRepository: userRepository)
         let fetchHomeDiningListUseCase = DefaultFetchHomeDiningListUseCase(
             fetchDiningListUseCase: DefaultFetchDiningListUseCase(diningRepository: diningRepository),
+            fetchCoopShopListUseCase: DefaultFetchCoopShopListUseCase(diningRepository: diningRepository),
             dateProvider: DefaultDateProvider()
         )
         let fetchCountsUseCase = DefaultFetchNewHomeCountsUseCase(

--- a/Koin/Presentation/Login/FindPassword/ChangePasswordSuccessViewController.swift
+++ b/Koin/Presentation/Login/FindPassword/ChangePasswordSuccessViewController.swift
@@ -121,6 +121,7 @@ extension ChangePasswordSuccessViewController {
         let fetchHomeHeaderUseCase = DefaultFetchHomeHeaderUseCase(homeRepository: homeRepository, userRepository: userRepository)
         let fetchHomeDiningListUseCase = DefaultFetchHomeDiningListUseCase(
             fetchDiningListUseCase: DefaultFetchDiningListUseCase(diningRepository: diningRepository),
+            fetchCoopShopListUseCase: DefaultFetchCoopShopListUseCase(diningRepository: diningRepository),
             dateProvider: DefaultDateProvider()
         )
         let fetchCountsUseCase = DefaultFetchNewHomeCountsUseCase(

--- a/Koin/Presentation/Login/Login/LoginViewController.swift
+++ b/Koin/Presentation/Login/Login/LoginViewController.swift
@@ -377,6 +377,7 @@ extension LoginViewController {
         let fetchHomeHeaderUseCase = DefaultFetchHomeHeaderUseCase(homeRepository: homeRepository, userRepository: userRepository)
         let fetchHomeDiningListUseCase = DefaultFetchHomeDiningListUseCase(
             fetchDiningListUseCase: DefaultFetchDiningListUseCase(diningRepository: diningRepository),
+            fetchCoopShopListUseCase: DefaultFetchCoopShopListUseCase(diningRepository: diningRepository),
             dateProvider: DefaultDateProvider()
         )
         let fetchCountsUseCase = DefaultFetchNewHomeCountsUseCase(

--- a/Koin/Presentation/NewHome/Home/Subviews/DiningView/Subviews/DiningMenuCard.swift
+++ b/Koin/Presentation/NewHome/Home/Subviews/DiningView/Subviews/DiningMenuCard.swift
@@ -14,28 +14,6 @@ struct DiningMenuCard: View {
 
     private let contentWidth: CGFloat = 266
 
-    private var menuLines: [String] {
-        let menuText = item.menu
-            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-            .filter { !$0.isEmpty }
-            .joined(separator: " · ")
-        guard !menuText.isEmpty else { return [""] }
-        guard menuText.width(using: .appFont(.pretendardMedium, size: 14)) > contentWidth else {
-            return [menuText]
-        }
-
-        let splitIndex = menuText.fittingPrefixIndex(
-            maxWidth: contentWidth,
-            font: .appFont(.pretendardMedium, size: 14)
-        )
-        let firstLine = String(menuText[..<splitIndex])
-            .trimmingMenuLine()
-        let secondLine = String(menuText[splitIndex...])
-            .trimmingMenuLine()
-
-        return secondLine.isEmpty ? [firstLine] : [firstLine, secondLine]
-    }
-
     var body: some View {
         Button(action: action) {
             VStack(alignment: .leading, spacing: 11) {
@@ -44,9 +22,9 @@ struct DiningMenuCard: View {
                         .font(.appFont(.pretendardMedium, size: 12))
                         .foregroundStyle(Color.ColorSystem.Neutral.gray600)
                         .frame(height: 19.2)
-
+                    
                     Spacer(minLength: 8)
-
+                    
                     HStack(spacing: 2) {
                         if let priceText = item.priceText {
                             Text(priceText)
@@ -54,14 +32,14 @@ struct DiningMenuCard: View {
                                 .foregroundStyle(Color.ColorSystem.Neutral.gray600)
                                 .frame(height: 19.2)
                         }
-
+                        
                         if item.priceText != nil, item.kcalText != nil {
                             Text("·")
                                 .font(.appFont(.pretendardSemiBold, size: 12))
                                 .foregroundStyle(Color.ColorSystem.Neutral.gray600)
                                 .frame(height: 19.2)
                         }
-
+                        
                         if let kcalText = item.kcalText {
                             Text(kcalText)
                                 .font(.appFont(.pretendardSemiBold, size: 12))
@@ -71,20 +49,19 @@ struct DiningMenuCard: View {
                     }
                 }
                 .frame(height: 19.2)
-
+                
                 Text(item.placeName)
                     .font(.appFont(.pretendardBold, size: 20))
                     .foregroundStyle(Color.ColorSystem.Neutral.gray800)
                     .frame(height: 32)
-
-                ForEach(Array(menuLines.enumerated()), id: \.offset) { index, line in
-                    Text(line)
-                        .font(.appFont(.pretendardMedium, size: 14))
-                        .foregroundStyle(Color.ColorSystem.Neutral.gray600)
-                        .lineLimit(1)
-                        .truncationMode(.tail)
-                        .frame(maxWidth: .infinity, minHeight: 22.4, maxHeight: 22.4, alignment: .leading)
-                }
+                
+                Text(item.menu.byCharWrapping)
+                    .font(.appFont(.pretendardMedium, size: 14))
+                    .linespacing(fontSize: 14, percent: 236)
+                    .foregroundStyle(Color.ColorSystem.Neutral.gray600)
+                    .lineLimit(2)
+                    .truncationMode(.tail)
+                    .multilineTextAlignment(.leading)
             }
             .padding(.horizontal, 23)
             .padding(.vertical, 21)
@@ -97,36 +74,5 @@ struct DiningMenuCard: View {
             }
         }
         .buttonStyle(.plain)
-    }
-}
-
-private extension String {
-    func width(using font: UIFont) -> CGFloat {
-        (self as NSString).size(withAttributes: [.font: font]).width
-    }
-
-    func fittingPrefixIndex(maxWidth: CGFloat, font: UIFont) -> String.Index {
-        var low = 0
-        var high = count
-        var best = 1
-
-        while low <= high {
-            let mid = (low + high) / 2
-            let index = self.index(startIndex, offsetBy: mid)
-            let candidate = String(self[..<index])
-
-            if candidate.width(using: font) <= maxWidth {
-                best = max(mid, 1)
-                low = mid + 1
-            } else {
-                high = mid - 1
-            }
-        }
-
-        return index(startIndex, offsetBy: best)
-    }
-
-    func trimmingMenuLine() -> String {
-        trimmingCharacters(in: CharacterSet(charactersIn: " ·\n\t"))
     }
 }

--- a/Koin/Presentation/NewHome/Home/Subviews/DiningView/Subviews/DiningMenuCard.swift
+++ b/Koin/Presentation/NewHome/Home/Subviews/DiningView/Subviews/DiningMenuCard.swift
@@ -18,11 +18,11 @@ struct DiningMenuCard: View {
         Button(action: action) {
             VStack(alignment: .leading, spacing: 11) {
                 HStack {
-                    Text(item.timeText)
+                    Text(item.timeText ?? "")
                         .font(.appFont(.pretendardMedium, size: 12))
                         .foregroundStyle(Color.ColorSystem.Neutral.gray600)
                         .frame(height: 19.2)
-                    
+                        .isHidden(item.timeText == nil)
                     Spacer(minLength: 8)
                     
                     HStack(spacing: 2) {

--- a/Koin/Presentation/NewHome/Home/Subviews/HomeHeaderView.swift
+++ b/Koin/Presentation/NewHome/Home/Subviews/HomeHeaderView.swift
@@ -32,7 +32,7 @@ struct HomeHeaderView: View {
             }
 
             VStack(alignment: .leading, spacing: 0) {
-                Text(verbatim: "\(header.userName)님,")
+                Text(verbatim: "\(header.userName ?? "익명")님,")
                     .font(.appFont(.pretendardBold, size: 24))
                     .foregroundStyle(Color(hex: "0B0B0D"))
 

--- a/koin.xcodeproj/project.pbxproj
+++ b/koin.xcodeproj/project.pbxproj
@@ -59,10 +59,9 @@
 		7C457AE72FCDE7240011D338 /* SwiftUIViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C457AE62FCDE7240011D338 /* SwiftUIViewModelProtocol.swift */; };
 		7C457B2B2FCE1BA80011D338 /* DiningView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C457B092FCE1BA80011D338 /* DiningView.swift */; };
 		7C457B2C2FCE1BA80011D338 /* HomeTabbarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C457B1E2FCE1BA80011D338 /* HomeTabbarController.swift */; };
-        7C457B2D2FCE1BA80011D338 /* HomeTabbarViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C457B202FCE1BA80011D338 /* HomeTabbarViewModel.swift */; };
-        7C457B2F2FCE1BA80011D338 /* HomeTabbarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C457B1C2FCE1BA80011D338 /* HomeTabbarView.swift */; };
-        7C457B432FCE1BA80011D338 /* CategoryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C457B412FCE1BA80011D338 /* CategoryViewModel.swift */; };
-        7C457B302FCE1BA80011D338 /* HomeHostingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C457B182FCE1BA80011D338 /* HomeHostingController.swift */; };
+		7C457B2D2FCE1BA80011D338 /* HomeTabbarViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C457B202FCE1BA80011D338 /* HomeTabbarViewModel.swift */; };
+		7C457B2F2FCE1BA80011D338 /* HomeTabbarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C457B1C2FCE1BA80011D338 /* HomeTabbarView.swift */; };
+		7C457B302FCE1BA80011D338 /* HomeHostingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C457B182FCE1BA80011D338 /* HomeHostingController.swift */; };
 		7C457B332FCE1BA80011D338 /* CategoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C457B062FCE1BA80011D338 /* CategoryView.swift */; };
 		7C457B342FCE1BA80011D338 /* ShuttleTicketButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C457B0F2FCE1BA80011D338 /* ShuttleTicketButton.swift */; };
 		7C457B362FCE1BA80011D338 /* CategoryHostingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C457B052FCE1BA80011D338 /* CategoryHostingController.swift */; };
@@ -73,6 +72,7 @@
 		7C457B3F2FCE1BA80011D338 /* CategorySection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C457B022FCE1BA80011D338 /* CategorySection.swift */; };
 		7C457B402FCE1BA80011D338 /* HomeTabbarItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C457B1B2FCE1BA80011D338 /* HomeTabbarItemView.swift */; };
 		7C457B422FCE1BA80011D338 /* MobilityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C457B112FCE1BA80011D338 /* MobilityView.swift */; };
+		7C457B432FCE1BA80011D338 /* CategoryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C457B412FCE1BA80011D338 /* CategoryViewModel.swift */; };
 		7C457B442FCE1BA80011D338 /* CallVanRecruitmentButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C457B0D2FCE1BA80011D338 /* CallVanRecruitmentButton.swift */; };
 		7C457B452FCE1BA80011D338 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C457B192FCE1BA80011D338 /* HomeView.swift */; };
 		7C457B492FCE1BA80011D338 /* ShopView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C457B132FCE1BA80011D338 /* ShopView.swift */; };
@@ -216,6 +216,7 @@
 		7C8A94402FD426B400DEA6F5 /* HomeRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C8A943F2FD426B400DEA6F5 /* HomeRepository.swift */; };
 		7C8A94422FD4278800DEA6F5 /* HomeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C8A94412FD4278800DEA6F5 /* HomeService.swift */; };
 		7C8A94442FD4279B00DEA6F5 /* HomeAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C8A94432FD4279B00DEA6F5 /* HomeAPI.swift */; };
+		7C8A94462FD50E8400DEA6F5 /* String+byCharWrapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C8A94452FD50E8400DEA6F5 /* String+byCharWrapping.swift */; };
 		7C8ADD2D2F20B43F00F85BDE /* UpdateLostItemRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C8ADD2C2F20B43F00F85BDE /* UpdateLostItemRequest.swift */; };
 		7C8ADD332F20BEC200F85BDE /* LostItemService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C8ADD322F20BEC200F85BDE /* LostItemService.swift */; };
 		7C8ADD352F20BF4600F85BDE /* LostItemAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C8ADD342F20BF4600F85BDE /* LostItemAPI.swift */; };
@@ -1058,7 +1059,6 @@
 		7C457B022FCE1BA80011D338 /* CategorySection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategorySection.swift; sourceTree = "<group>"; };
 		7C457B052FCE1BA80011D338 /* CategoryHostingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryHostingController.swift; sourceTree = "<group>"; };
 		7C457B062FCE1BA80011D338 /* CategoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryView.swift; sourceTree = "<group>"; };
-		7C457B412FCE1BA80011D338 /* CategoryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryViewModel.swift; sourceTree = "<group>"; };
 		7C457B092FCE1BA80011D338 /* DiningView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiningView.swift; sourceTree = "<group>"; };
 		7C457B0D2FCE1BA80011D338 /* CallVanRecruitmentButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallVanRecruitmentButton.swift; sourceTree = "<group>"; };
 		7C457B0E2FCE1BA80011D338 /* MobilitySmallButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobilitySmallButton.swift; sourceTree = "<group>"; };
@@ -1072,6 +1072,7 @@
 		7C457B1C2FCE1BA80011D338 /* HomeTabbarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeTabbarView.swift; sourceTree = "<group>"; };
 		7C457B1E2FCE1BA80011D338 /* HomeTabbarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeTabbarController.swift; sourceTree = "<group>"; };
 		7C457B202FCE1BA80011D338 /* HomeTabbarViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeTabbarViewModel.swift; sourceTree = "<group>"; };
+		7C457B412FCE1BA80011D338 /* CategoryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryViewModel.swift; sourceTree = "<group>"; };
 		7C4C714D2FBECB3D009D9875 /* SendDeviceTokenIfNeededUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendDeviceTokenIfNeededUseCase.swift; sourceTree = "<group>"; };
 		7C4D5A0D2F01638800B40128 /* BusAreaSelectdViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BusAreaSelectdViewController.swift; sourceTree = "<group>"; };
 		7C4D5A0E2F01638800B40128 /* BusAreaSelectedCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BusAreaSelectedCollectionView.swift; sourceTree = "<group>"; };
@@ -1212,6 +1213,7 @@
 		7C8A943F2FD426B400DEA6F5 /* HomeRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeRepository.swift; sourceTree = "<group>"; };
 		7C8A94412FD4278800DEA6F5 /* HomeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeService.swift; sourceTree = "<group>"; };
 		7C8A94432FD4279B00DEA6F5 /* HomeAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeAPI.swift; sourceTree = "<group>"; };
+		7C8A94452FD50E8400DEA6F5 /* String+byCharWrapping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+byCharWrapping.swift"; sourceTree = "<group>"; };
 		7C8ADD2C2F20B43F00F85BDE /* UpdateLostItemRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateLostItemRequest.swift; sourceTree = "<group>"; };
 		7C8ADD322F20BEC200F85BDE /* LostItemService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LostItemService.swift; sourceTree = "<group>"; };
 		7C8ADD342F20BF4600F85BDE /* LostItemAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LostItemAPI.swift; sourceTree = "<group>"; };
@@ -2471,6 +2473,7 @@
 				7C6790682FCC48A60045E163 /* Date+.swift */,
 				7C6790692FCC48A60045E163 /* Int+.swift */,
 				7C67906A2FCC48A60045E163 /* String+.swift */,
+				7C8A94452FD50E8400DEA6F5 /* String+byCharWrapping.swift */,
 				7C67906B2FCC48A60045E163 /* TimeInterval+.swift */,
 				7C67909D2FCC48BF0045E163 /* Bundle+APIKey.swift */,
 			);
@@ -5728,6 +5731,7 @@
 				B61FAA172EA3A39D005BE539 /* Typography.swift in Sources */,
 				7C61D3532F22E686005FAC3A /* DeleteLostItemUseCase.swift in Sources */,
 				8344D5C52C9BA2C9007CA555 /* SearchNoticeArticlesUseCase.swift in Sources */,
+				7C8A94462FD50E8400DEA6F5 /* String+byCharWrapping.swift in Sources */,
 				83E96DB82BBC6FBF00164914 /* BusSearchDTO.swift in Sources */,
 				7CC42B0E2F56AB7900940CE1 /* CallVanListViewController.swift in Sources */,
 				835C991A2C7EDB63002E02D3 /* FetchNotificationKeywordUseCase.swift in Sources */,


### PR DESCRIPTION
## #️⃣연관된 이슈

- #461 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

1. 식단 시간 API 연결
    - 하드코딩된 홈화면 식단 시간을 삭제하고 API를 연결합니다. 
    - coopshop API 으로 평일 아침, 점심, 저녁 시간을 꺼내서 조립합니다.
    - 값이 없을 경우 시간을 표시하지 않습니다.

2. 데이터 호출 실패 버그 수정
    - 홈화면에 필요한 데이터 호출시 여러 UseCase의 메서드를 zip으로 연결하여 조립합니다.
    - 비로그인시 호출하면 실패하는 fetchUser() 로 인해 연결된 모든 데이터 호출을 실패하는 버그가 있었습니다.
    - fetchUser()의 실패를 catch 하도록 변경하여 해결했습니다.

3. 식단 카드 뷰 로직을 개선합니다.
    - 문자열을 두개로 분리하여 Text 두개에 각각 담는 기존 로직을 개선합니다.
    - Text 두개처럼 보이도록 행간을 조절하고 문자열을 그대로 담아서 로직을 간소화했습니다.
    - SwiftUI Text에서는 lineBreakMode를 사용할 수 없으므로, 문자열의 각 문자 사이에 zero width space를 삽입하는 String+byCharWrapping 익스텐션을 추가 및 활용하여 줄바꿈 되도록 했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Coop shop opening times now displayed alongside dining menu information

* **Improvements**
  * Enhanced menu text display and formatting for better readability
  * Improved handling of missing user data—now displays "Anonymous" when unavailable
  * Optimized login flow with faster local authentication verification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->