### PR TITLE
feat: 홈화면 배너

### DIFF
--- a/Koin/Apps/SceneDelegate.swift
+++ b/Koin/Apps/SceneDelegate.swift
@@ -228,9 +228,11 @@ extension SceneDelegate {
             fetchHomeDiningListUseCase: fetchHomeDiningListUseCase,
             fetchCountsUseCase: fetchCountsUseCase,
             checkVersionUseCase: checkVersionUseCase,
+            checkLoginUseCase: DefaultCheckLoginUseCase(userRepository: userRepository),
             fetchUserDataUseCase: fetchUserDataUseCase,
             sendDeviceTokenIfNeededUseCase: SendDeviceTokenIfNeededUseCase,
-            logAnalyticsEventUseCase: logAnalyticsEventUseCase
+            logAnalyticsEventUseCase: logAnalyticsEventUseCase,
+            fetchBannerUseCase: DefaultFetchBannerUseCase(coreRepository: coreRepository)
         )
         return HomeView(viewModel: viewModel)
     }

--- a/Koin/Core/Logger/EventParameter.swift
+++ b/Koin/Core/Logger/EventParameter.swift
@@ -124,6 +124,9 @@ enum EventParameter {
             case categoryEtc = "category_etc"
             case mainBusTimetable = "main_bus_timetable"
             case mainBusSearch = "main_bus_search"
+            case mainNextModal = "main_next_modal"
+            case mainModalHide7d = "main_modal_hide_7d"
+            case mainModalClose = "main_modal_close"
             
             case departureBox = "departure_box"
             case arrivalBox = "arrival_box"

--- a/Koin/Core/View/AutoScrollableInfiniteCarouselCollectionView/AutoScrollableInfiniteCarouselCollectionView.swift
+++ b/Koin/Core/View/AutoScrollableInfiniteCarouselCollectionView/AutoScrollableInfiniteCarouselCollectionView.swift
@@ -1,0 +1,222 @@
+//
+//  AutoScrollableInfiniteCarouselCollectionView.swift
+//  koin
+//
+//  Created by 홍기정 on 6/20/26.
+//
+
+import UIKit
+
+class AutoScrollableInfiniteCarouselCollectionView: UICollectionView {
+    
+    // MARK: - Properties
+    weak var carouselDelegate: (any AutoScrollableInfiniteCarouselCollectionViewProtocol)?
+    
+    var autoScrollInterval: TimeInterval? {
+        didSet { resetAutoScrollTimer() }
+    }
+    
+    var currentItemIndex: Int? {
+        guard realItemCount > 0 else { return nil }
+        return logicalIndex(for: currentPhysicalIndex)
+    }
+    
+    private var timer: Timer?
+    private var needsInitialPosition = false
+    private var isUserScrolling = false
+    
+    private var realItemCount: Int {
+        max(carouselDelegate?.numberOfItems(in: self) ?? 0, 0)
+    }
+    
+    private var displayedItemCount: Int {
+        realItemCount > 1 ? realItemCount + 2 : realItemCount
+    }
+    
+    private var currentPhysicalIndex: Int {
+        guard bounds.width > 0 else { return initialPhysicalIndex }
+        let index = Int(round(contentOffset.x / bounds.width))
+        return min(max(index, 0), max(displayedItemCount - 1, 0))
+    }
+    
+    private var initialPhysicalIndex: Int {
+        realItemCount > 1 ? 1 : 0
+    }
+    
+    // MARK: - Initializer
+    override init(frame: CGRect, collectionViewLayout layout: UICollectionViewLayout) {
+        super.init(frame: frame, collectionViewLayout: layout)
+        configureCollectionView()
+    }
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    deinit {
+        timer?.invalidate()
+    }
+    
+    // MARK: - Life Cycle
+    override func didMoveToWindow() {
+        super.didMoveToWindow()
+        window == nil ? stopAutoScroll() : startAutoScroll()
+    }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        guard needsInitialPosition, bounds.width > 0 else { return }
+        moveToPhysicalIndex(initialPhysicalIndex, animated: false)
+        needsInitialPosition = false
+    }
+    
+    // MARK: - Methods
+    func reloadCarouselData() {
+        stopAutoScroll()
+        reloadData()
+        needsInitialPosition = true
+        setNeedsLayout()
+        startAutoScroll()
+    }
+}
+
+extension AutoScrollableInfiniteCarouselCollectionView {
+
+    private func startAutoScroll() {
+        guard let autoScrollInterval,
+              timer == nil,
+              window != nil,
+              realItemCount > 1,
+              autoScrollInterval > 0,
+              !isDragging,
+              !isDecelerating else { return }
+
+        let timer = Timer(timeInterval: autoScrollInterval, repeats: true) { [weak self] _ in
+            self?.scrollToNextItem()
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        self.timer = timer
+    }
+
+    private func stopAutoScroll() {
+        timer?.invalidate()
+        timer = nil
+    }
+    
+    private func configureCollectionView() {
+        dataSource = self
+        delegate = self
+        isPagingEnabled = true
+        decelerationRate = .fast
+        showsHorizontalScrollIndicator = false
+
+        if let flowLayout = collectionViewLayout as? UICollectionViewFlowLayout {
+            flowLayout.scrollDirection = .horizontal
+            flowLayout.minimumLineSpacing = 0
+            flowLayout.minimumInteritemSpacing = 0
+        }
+    }
+
+    private func logicalIndex(for physicalIndex: Int) -> Int {
+        guard realItemCount > 1 else { return 0 }
+
+        switch physicalIndex {
+        case 0:
+            return realItemCount - 1
+        case realItemCount + 1:
+            return 0
+        default:
+            return physicalIndex - 1
+        }
+    }
+
+    private func moveToPhysicalIndex(_ index: Int, animated: Bool) {
+        guard displayedItemCount > index else { return }
+        scrollToItem(
+            at: IndexPath(item: index, section: 0),
+            at: .centeredHorizontally,
+            animated: animated
+        )
+    }
+
+    private func correctPositionIfNeeded(at physicalIndex: Int) {
+        guard realItemCount > 1 else { return }
+
+        if physicalIndex == 0 {
+            moveToPhysicalIndex(realItemCount, animated: false)
+        } else if physicalIndex == realItemCount + 1 {
+            moveToPhysicalIndex(1, animated: false)
+        }
+    }
+
+    private func resetAutoScrollTimer() {
+        stopAutoScroll()
+        startAutoScroll()
+    }
+
+    private func scrollToNextItem() {
+        guard realItemCount > 1 else { return }
+        moveToPhysicalIndex(currentPhysicalIndex + 1, animated: true)
+    }
+
+    private func handleScrollFinished() {
+        guard realItemCount > 0 else { return }
+
+        let physicalIndex = currentPhysicalIndex
+        let logicalIndex = logicalIndex(for: physicalIndex)
+        correctPositionIfNeeded(at: physicalIndex)
+        carouselDelegate?.collectionView(
+            self,
+            didMoveToItemAt: logicalIndex,
+            isUserInitiated: isUserScrolling
+        )
+        isUserScrolling = false
+        resetAutoScrollTimer()
+    }
+}
+
+extension AutoScrollableInfiniteCarouselCollectionView: UICollectionViewDataSource {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        displayedItemCount
+    }
+
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        guard let carouselDelegate else { return UICollectionViewCell() }
+        return carouselDelegate.collectionView(
+            self,
+            cellForItemAt: logicalIndex(for: indexPath.item),
+            dequeueAt: indexPath
+        )
+    }
+}
+
+extension AutoScrollableInfiniteCarouselCollectionView: UICollectionViewDelegateFlowLayout {
+    func collectionView(
+        _ collectionView: UICollectionView,
+        layout collectionViewLayout: UICollectionViewLayout,
+        sizeForItemAt indexPath: IndexPath
+    ) -> CGSize {
+        collectionView.bounds.size
+    }
+
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        guard realItemCount > 0 else { return }
+        carouselDelegate?.collectionView(self, didSelectItemAt: logicalIndex(for: indexPath.item))
+    }
+
+    func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
+        isUserScrolling = true
+        stopAutoScroll()
+    }
+
+    func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
+        if !decelerate { handleScrollFinished() }
+    }
+
+    func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
+        handleScrollFinished()
+    }
+
+    func scrollViewDidEndScrollingAnimation(_ scrollView: UIScrollView) {
+        handleScrollFinished()
+    }
+}

--- a/Koin/Core/View/AutoScrollableInfiniteCarouselCollectionView/AutoScrollableInfiniteCarouselCollectionViewProtocol.swift
+++ b/Koin/Core/View/AutoScrollableInfiniteCarouselCollectionView/AutoScrollableInfiniteCarouselCollectionViewProtocol.swift
@@ -1,0 +1,31 @@
+//
+//  AutoScrollableInfiniteCarouselCollectionViewProtocol.swift
+//  koin
+//
+//  Created by 홍기정 on 6/20/26.
+//
+
+import UIKit
+
+@MainActor
+protocol AutoScrollableInfiniteCarouselCollectionViewProtocol: AnyObject {
+    
+    func numberOfItems(in collectionView: AutoScrollableInfiniteCarouselCollectionView) -> Int
+    
+    func collectionView(
+        _ collectionView: AutoScrollableInfiniteCarouselCollectionView,
+        cellForItemAt index: Int,
+        dequeueAt indexPath: IndexPath
+    ) -> UICollectionViewCell
+    
+    func collectionView(
+        _ collectionView: AutoScrollableInfiniteCarouselCollectionView,
+        didSelectItemAt index: Int
+    )
+    
+    func collectionView(
+        _ collectionView: AutoScrollableInfiniteCarouselCollectionView,
+        didMoveToItemAt index: Int,
+        isUserInitiated: Bool
+    )
+}

--- a/Koin/Presentation/Home/Home/SubViews/ForceModifyUserViewController.swift
+++ b/Koin/Presentation/Home/Home/SubViews/ForceModifyUserViewController.swift
@@ -133,9 +133,11 @@ extension ForceModifyUserViewController {
             fetchHomeDiningListUseCase: fetchHomeDiningListUseCase,
             fetchCountsUseCase: fetchCountsUseCase,
             checkVersionUseCase: checkVersionUseCase,
+            checkLoginUseCase: DefaultCheckLoginUseCase(userRepository: userRepository),
             fetchUserDataUseCase: fetchUserDataUseCase,
             sendDeviceTokenIfNeededUseCase: SendDeviceTokenIfNeededUseCase,
-            logAnalyticsEventUseCase: logAnalyticsEventUseCase
+            logAnalyticsEventUseCase: logAnalyticsEventUseCase,
+            fetchBannerUseCase: DefaultFetchBannerUseCase(coreRepository: coreRepository)
         )
         return HomeView(viewModel: viewModel)
     }

--- a/Koin/Presentation/Login/FindId/ViewControllers/FoundIdViewController.swift
+++ b/Koin/Presentation/Login/FindId/ViewControllers/FoundIdViewController.swift
@@ -168,9 +168,11 @@ extension FoundIdViewController {
             fetchHomeDiningListUseCase: fetchHomeDiningListUseCase,
             fetchCountsUseCase: fetchCountsUseCase,
             checkVersionUseCase: checkVersionUseCase,
+            checkLoginUseCase: DefaultCheckLoginUseCase(userRepository: userRepository),
             fetchUserDataUseCase: fetchUserDataUseCase,
             sendDeviceTokenIfNeededUseCase: SendDeviceTokenIfNeededUseCase,
-            logAnalyticsEventUseCase: logAnalyticsEventUseCase
+            logAnalyticsEventUseCase: logAnalyticsEventUseCase,
+            fetchBannerUseCase: DefaultFetchBannerUseCase(coreRepository: coreRepository)
         )
         return HomeView(viewModel: viewModel)
     }

--- a/Koin/Presentation/Login/FindPassword/ChangePasswordSuccessViewController.swift
+++ b/Koin/Presentation/Login/FindPassword/ChangePasswordSuccessViewController.swift
@@ -141,9 +141,11 @@ extension ChangePasswordSuccessViewController {
             fetchHomeDiningListUseCase: fetchHomeDiningListUseCase,
             fetchCountsUseCase: fetchCountsUseCase,
             checkVersionUseCase: checkVersionUseCase,
+            checkLoginUseCase: DefaultCheckLoginUseCase(userRepository: userRepository),
             fetchUserDataUseCase: fetchUserDataUseCase,
             sendDeviceTokenIfNeededUseCase: SendDeviceTokenIfNeededUseCase,
-            logAnalyticsEventUseCase: logAnalyticsEventUseCase
+            logAnalyticsEventUseCase: logAnalyticsEventUseCase,
+            fetchBannerUseCase: DefaultFetchBannerUseCase(coreRepository: coreRepository)
         )
         return HomeView(viewModel: viewModel)
     }

--- a/Koin/Presentation/Login/Login/LoginViewController.swift
+++ b/Koin/Presentation/Login/Login/LoginViewController.swift
@@ -397,9 +397,11 @@ extension LoginViewController {
             fetchHomeDiningListUseCase: fetchHomeDiningListUseCase,
             fetchCountsUseCase: fetchCountsUseCase,
             checkVersionUseCase: checkVersionUseCase,
+            checkLoginUseCase: DefaultCheckLoginUseCase(userRepository: userRepository),
             fetchUserDataUseCase: fetchUserDataUseCase,
             sendDeviceTokenIfNeededUseCase: SendDeviceTokenIfNeededUseCase,
-            logAnalyticsEventUseCase: logAnalyticsEventUseCase
+            logAnalyticsEventUseCase: logAnalyticsEventUseCase,
+            fetchBannerUseCase: DefaultFetchBannerUseCase(coreRepository: coreRepository)
         )
         return HomeView(viewModel: viewModel)
     }

--- a/Koin/Presentation/NewHome/Home/HomeHostingController.swift
+++ b/Koin/Presentation/NewHome/Home/HomeHostingController.swift
@@ -44,6 +44,8 @@ final class HomeHostingController: UIHostingController<HomeView>, HostingControl
             navigationController?.present(makeForceModifyUserViewController(), animated: true)
         case let .showToast(message):
             showToastMessage(message: message)
+        case let .showBanner(banner, isLoggedIn):
+            showBanner(banner, isLoggedIn: isLoggedIn)
         }
     }
 }
@@ -157,5 +159,166 @@ extension HomeHostingController {
 
     private func makeForceModifyUserViewController() -> UIViewController {
         return ForceModifyUserViewController()
+    }
+}
+
+// MARK: - Banner
+
+extension HomeHostingController {
+    private func showBanner(_ banner: BannerDto, isLoggedIn: Bool) {
+        guard banner.count > 0, !banner.banners.isEmpty else { return }
+
+        let logAnalyticsEventUseCase = DefaultLogAnalyticsEventUseCase(
+            repository: GA4AnalyticsRepository(service: GA4AnalyticsService())
+        )
+        let bannerViewController = NewBannerViewController(
+            onBannerTap: { [weak self] banner in
+                self?.handleBannerTap(banner, isLoggedIn: isLoggedIn)
+            },
+            onLogEvent: { label, category, value in
+                logAnalyticsEventUseCase.execute(
+                    label: label,
+                    category: category,
+                    value: value
+                )
+            }
+        )
+        bannerViewController.setBanners(banner.banners)
+
+        let bottomSheetViewController = BottomSheetViewController(
+            contentViewController: bannerViewController,
+            defaultHeight: 341 + UIApplication.bottomSafeAreaHeight()
+        )
+        bottomSheetViewController.modalPresentationStyle = .overFullScreen
+        bottomSheetViewController.modalTransitionStyle = .crossDissolve
+        logAnalyticsEventUseCase.logEvent(
+            name: "CAMPUS",
+            label: "main_modal_entry",
+            value: banner.banners.first?.title ?? "",
+            category: "entry"
+        )
+        present(bottomSheetViewController, animated: true)
+    }
+
+    private func handleBannerTap(_ banner: Banner, isLoggedIn: Bool) {
+        dismiss(animated: true)
+        let logAnalyticsEventUseCase = DefaultLogAnalyticsEventUseCase(
+            repository: GA4AnalyticsRepository(service: GA4AnalyticsService())
+        )
+        logAnalyticsEventUseCase.logEvent(
+            name: "CAMPUS",
+            label: "main_modal",
+            value: banner.title,
+            category: "click"
+        )
+
+        if let version = banner.version,
+           isVersion(currentAppVersion, lowerThan: version) {
+            showToast(message: "해당 기능을 사용하기 위해서는 업데이트가 꼭 필요해요")
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+                guard let appStoreURL = URL(string: "https://apps.apple.com/kr/app/%EC%BD%94%EC%9D%B8-koreatech-in-%ED%95%9C%EA%B8%B0%EB%8C%80-%EC%BB%A4%EB%AE%A4%EB%8B%88%ED%8B%B0/id1500848622") else { return }
+                UIApplication.shared.open(appStoreURL)
+            }
+            return
+        }
+
+        switch banner.redirectLink {
+        case "shop":
+            navigationController?.pushViewController(makeShopViewController(), animated: true)
+        case "dining":
+            navigationController?.pushViewController(makeDiningViewController(), animated: true)
+        case "keyword":
+            navigationController?.pushViewController(makeManageNoticeKeywordViewController(), animated: true)
+        case "timetable":
+            guard isLoggedIn else {
+                showToast(message: "로그인이 필요한 기능입니다.", success: true)
+                return
+            }
+            navigationController?.pushViewController(
+                TimetableViewController(viewModel: TimetableViewModel()),
+                animated: true
+            )
+        case "login":
+            navigationController?.pushViewController(makeLoginViewController(), animated: true)
+        case "chat":
+            guard isLoggedIn else {
+                showToast(message: "로그인이 필요한 기능입니다.")
+                return
+            }
+            navigationController?.pushViewController(
+                ChatListTableViewController(viewModel: ChatListTableViewModel()),
+                animated: true
+            )
+        case "lostitem":
+            navigationController?.pushViewController(makeLostItemListViewController(), animated: true)
+        case "home", .none:
+            return
+        default:
+            return
+        }
+    }
+
+    private var currentAppVersion: String {
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
+    }
+
+    private func isVersion(_ currentVersion: String, lowerThan requiredVersion: String) -> Bool {
+        let currentComponents = currentVersion.split(separator: ".").compactMap { Int($0) }
+        let requiredComponents = requiredVersion.split(separator: ".").compactMap { Int($0) }
+
+        for index in 0..<max(currentComponents.count, requiredComponents.count) {
+            let current = index < currentComponents.count ? currentComponents[index] : 0
+            let required = index < requiredComponents.count ? requiredComponents[index] : 0
+            if current < required { return true }
+            if current > required { return false }
+        }
+        return false
+    }
+
+    private func makeManageNoticeKeywordViewController() -> UIViewController {
+        let noticeRepository = DefaultNoticeListRepository(service: DefaultNoticeService())
+        let notiRepository = DefaultNotiRepository(service: DefaultNotiService())
+        let viewModel = ManageNoticeKeywordViewModel(
+            addNotificationKeywordUseCase: DefaultAddNotificationKeywordUseCase(noticeListRepository: noticeRepository),
+            deleteNotificationKeywordUseCase: DefaultDeleteNotificationKeywordUseCase(noticeListRepository: noticeRepository),
+            fetchNotificationKeywordUseCase: DefaultFetchNotificationKeywordUseCase(noticeListRepository: noticeRepository),
+            fetchRecommendedKeywordUseCase: DefaultFetchRecommendedKeywordUseCase(noticeListRepository: noticeRepository),
+            changeNotiUseCase: DefaultChangeNotiUseCase(notiRepository: notiRepository),
+            fetchNotiListUseCase: DefaultFetchNotiListUseCase(notiRepository: notiRepository),
+            logAnalyticsEventUseCase: DefaultLogAnalyticsEventUseCase(
+                repository: GA4AnalyticsRepository(service: GA4AnalyticsService())
+            )
+        )
+        return ManageNoticeKeywordViewController(viewModel: viewModel)
+    }
+
+    private func makeLoginViewController() -> UIViewController {
+        let userRepository = DefaultUserRepository(service: DefaultUserService())
+        let viewModel = LoginViewModel(
+            loginUseCase: DefaultLoginUseCase(userRepository: userRepository),
+            logAnalyticsEventUseCase: DefaultLogAnalyticsEventUseCase(
+                repository: GA4AnalyticsRepository(service: GA4AnalyticsService())
+            ),
+            fetchUserDataUseCase: DefaultFetchUserDataUseCase(userRepository: userRepository),
+            sendDeviceTokenIfNeededUseCase: DefaultSendDeviceTokenIfNeededUseCase(
+                userRepository: userRepository,
+                notiRepository: DefaultNotiRepository(service: DefaultNotiService())
+            )
+        )
+        return LoginViewController(viewModel: viewModel)
+    }
+
+    private func makeLostItemListViewController() -> UIViewController {
+        let userRepository = DefaultUserRepository(service: DefaultUserService())
+        let lostItemRepository = DefaultLostItemRepository(service: DefaultLostItemService())
+        let viewModel = LostItemListViewModel(
+            checkLoginUseCase: DefaultCheckLoginUseCase(userRepository: userRepository),
+            fetchLostItemListUseCase: DefaultFetchLostItemListUseCase(repository: lostItemRepository),
+            logAnalyticsEventUseCase: DefaultLogAnalyticsEventUseCase(
+                repository: GA4AnalyticsRepository(service: GA4AnalyticsService())
+            ),
+            fetchMyKeywordUseCase: DefaultFetchLostItemMyKeywordUseCase(repository: lostItemRepository)
+        )
+        return LostItemListViewController(viewModel: viewModel)
     }
 }

--- a/Koin/Presentation/NewHome/Home/HomeView.swift
+++ b/Koin/Presentation/NewHome/Home/HomeView.swift
@@ -19,6 +19,7 @@ struct HomeView: View, ActionBindableView {
         case showForceUpdate(String)
         case showForceModifyUser
         case showToast(String)
+        case showBanner(BannerDto, isLoggedIn: Bool)
     }
 
     @State private var viewModel: NewHomeViewModel
@@ -100,7 +101,12 @@ struct HomeView: View, ActionBindableView {
         .onChange(of: viewModel.toastMessage) { _, message in
             guard let message else { return }
             sendAction(.showToast(message))
-            viewModel.execute(.markToastPresented)
+            viewModel.execute(.didShowToast)
+        }
+        .onChange(of: viewModel.bannerToPresent?.banners.first?.id) { _, _ in
+            guard let banner = viewModel.bannerToPresent else { return }
+            sendAction(.showBanner(banner, isLoggedIn: viewModel.isLoggedIn))
+            viewModel.execute(.didShowBanner)
         }
         .refreshable {
 

--- a/Koin/Presentation/NewHome/Home/NewHomeViewModel.swift
+++ b/Koin/Presentation/NewHome/Home/NewHomeViewModel.swift
@@ -15,28 +15,33 @@ final class NewHomeViewModel: SwiftUIViewModelProtocol {
     enum Input {
         case viewDidLoad
         case refresh
-        case markToastPresented
+        case didShowToast
+        case didShowBanner
         case logEvent(EventLabelType, EventParameter.EventCategory, Any)
     }
 
-    var header: HomeHeader = HomeHeader.empty()
-    var diningItems: [HomeDiningItem] = []
-    var callVanRecruitingCount: Int = 0
-    var eventCount: Int = 0
-    var openShopCount: Int = 0
-    var totalShopCount: Int = 0
-    var isLoading: Bool = false
-    var toastMessage: String?
-    var forceUpdateVersion: String?
-    var forceModifyUserRequired = false
+    private(set) var header: HomeHeader = HomeHeader.empty()
+    private(set) var  diningItems: [HomeDiningItem] = []
+    private(set) var  callVanRecruitingCount: Int = 0
+    private(set) var  eventCount: Int = 0
+    private(set) var  openShopCount: Int = 0
+    private(set) var  totalShopCount: Int = 0
+    private(set) var  isLoading: Bool = false
+    private(set) var  toastMessage: String?
+    private(set) var  forceUpdateVersion: String?
+    private(set) var  forceModifyUserRequired = false
+    private(set) var  bannerToPresent: BannerDto?
+    private(set) var  isLoggedIn = false
 
     private let fetchHomeHeaderUseCase: FetchHomeHeaderUseCase
     private let fetchHomeDiningListUseCase: FetchHomeDiningListUseCase
     private let fetchCountsUseCase: FetchNewHomeCountsUseCase
     private let checkVersionUseCase: CheckVersionUseCase
+    private let checkLoginUseCase: CheckLoginUseCase
     private let fetchUserDataUseCase: FetchUserDataUseCase
     private let sendDeviceTokenIfNeededUseCase: SendDeviceTokenIfNeededUseCase
     private let logAnalyticsEventUseCase: LogAnalyticsEventUseCase
+    private let fetchBannerUseCase: FetchBannerUseCase
     private var subscriptions: Set<AnyCancellable> = []
 
     init(
@@ -44,30 +49,39 @@ final class NewHomeViewModel: SwiftUIViewModelProtocol {
         fetchHomeDiningListUseCase: FetchHomeDiningListUseCase,
         fetchCountsUseCase: FetchNewHomeCountsUseCase,
         checkVersionUseCase: CheckVersionUseCase,
+        checkLoginUseCase: CheckLoginUseCase,
         fetchUserDataUseCase: FetchUserDataUseCase,
         sendDeviceTokenIfNeededUseCase: SendDeviceTokenIfNeededUseCase,
-        logAnalyticsEventUseCase: LogAnalyticsEventUseCase
+        logAnalyticsEventUseCase: LogAnalyticsEventUseCase,
+        fetchBannerUseCase: FetchBannerUseCase
     ) {
         self.fetchHomeHeaderUseCase = fetchHomeHeaderUseCase
         self.fetchHomeDiningListUseCase = fetchHomeDiningListUseCase
         self.fetchCountsUseCase = fetchCountsUseCase
         self.checkVersionUseCase = checkVersionUseCase
+        self.checkLoginUseCase = checkLoginUseCase
         self.fetchUserDataUseCase = fetchUserDataUseCase
         self.sendDeviceTokenIfNeededUseCase = sendDeviceTokenIfNeededUseCase
         self.logAnalyticsEventUseCase = logAnalyticsEventUseCase
+        self.fetchBannerUseCase = fetchBannerUseCase
     }
 
     func execute(_ input: Input) {
         switch input {
         case .viewDidLoad:
+            checkLogin { [weak self] in
+                self?.checkAndFetchBanner()
+            }
             checkVersion()
             checkForceModifyUser()
             sendDeviceTokenIfNeeded()
             loadHomeContent()
         case .refresh:
             loadHomeContent()
-        case .markToastPresented:
+        case .didShowToast:
             toastMessage = nil
+        case .didShowBanner:
+            bannerToPresent = nil
         case let .logEvent(label, category, value):
             makeLogAnalyticsEvent(label: label, category: category, value: value)
         }
@@ -75,7 +89,7 @@ final class NewHomeViewModel: SwiftUIViewModelProtocol {
 }
 
 extension NewHomeViewModel {
-    
+
     private func checkVersion() {
         checkVersionUseCase.execute()
             .sink(
@@ -88,10 +102,19 @@ extension NewHomeViewModel {
             )
             .store(in: &subscriptions)
     }
-    
+
+    private func checkLogin(completion: @escaping (() -> Void)) {
+        checkLoginUseCase.execute()
+            .sink { [weak self] isLoggedIn in
+                self?.isLoggedIn = isLoggedIn
+                completion()
+            }
+            .store(in: &subscriptions)
+    }
+
     private func checkForceModifyUser() {
         guard UserDefaults.standard.bool(forKey: "forceModal") == false else { return }
-        
+
         fetchUserDataUseCase.execute()
             .sink(
                 receiveCompletion: { _ in },
@@ -104,21 +127,21 @@ extension NewHomeViewModel {
                             userData.major == nil ||
                             userData.studentNumber == nil
                     else { return }
-                    
+
                     UserDefaults.standard.set(true, forKey: "forceModal")
                     self?.forceModifyUserRequired = true
                 }
             )
             .store(in: &subscriptions)
     }
-    
+
     private func sendDeviceTokenIfNeeded() {
         sendDeviceTokenIfNeededUseCase.execute()
     }
-    
+
     private func loadHomeContent() {
         isLoading = true
-        
+
         Publishers.Zip3(
             fetchHomeHeaderUseCase.execute(),
             fetchHomeDiningListUseCase.execute(),
@@ -143,7 +166,25 @@ extension NewHomeViewModel {
         )
         .store(in: &subscriptions)
     }
-    
+
+    private func checkAndFetchBanner() {
+        if let noShowDate = UserDefaults.standard.object(forKey: "noShowBanner") as? Date,
+           let thresholdDate = Calendar.current.date(byAdding: .day, value: 7, to: noShowDate),
+           Date() < thresholdDate {
+            return
+        }
+
+        fetchBannerUseCase.execute()
+            .sink(
+                receiveCompletion: { _ in },
+                receiveValue: { [weak self] banner in
+                    guard banner.count > 0, !banner.banners.isEmpty else { return }
+                    self?.bannerToPresent = banner
+                }
+            )
+            .store(in: &subscriptions)
+    }
+
     private func makeLogAnalyticsEvent(
         label: EventLabelType,
         category: EventParameter.EventCategory,

--- a/Koin/Presentation/NewHome/Home/Subviews/BannerView/NewBannerCollectionView.swift
+++ b/Koin/Presentation/NewHome/Home/Subviews/BannerView/NewBannerCollectionView.swift
@@ -1,0 +1,91 @@
+//
+//  NewBannerCollectionView.swift
+//  koin
+//
+//  Created by 홍기정 on 6/20/26.
+//
+
+import UIKit
+
+final class NewBannerCollectionView: AutoScrollableInfiniteCarouselCollectionView {
+
+    // MARK: - Properties
+    private var banners: [Banner] = []
+    private let onBannerTap: (Banner) -> Void
+    private let onPageChanged: (Int, Int) -> Void
+    private let onBannerSwiped: (Banner) -> Void
+
+    var currentTitle: String? {
+        if let currentItemIndex, banners.indices.contains(currentItemIndex) {
+            return banners[currentItemIndex].title
+        } else {
+            return nil
+        }
+    }
+
+    // MARK: - Initialization
+    init(
+        onBannerTap: @escaping (Banner) -> Void,
+        onPageChanged: @escaping (Int, Int) -> Void,
+        onBannerSwiped: @escaping (Banner) -> Void,
+    ) {
+        self.onBannerTap = onBannerTap
+        self.onPageChanged = onPageChanged
+        self.onBannerSwiped = onBannerSwiped
+        super.init(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
+        self.autoScrollInterval = 3
+        
+        carouselDelegate = self
+        register(BannerCollectionViewCell.self, forCellWithReuseIdentifier: BannerCollectionViewCell.identifier)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Methods
+    func setBanners(_ banners: [Banner]) {
+        self.banners = banners
+        reloadCarouselData()
+        onPageChanged(0, banners.count)
+    }
+}
+
+// MARK: - AutoScrollableInfiniteCarouselCollectionViewProtocol
+
+extension NewBannerCollectionView: AutoScrollableInfiniteCarouselCollectionViewProtocol {
+    
+    func numberOfItems(in collectionView: AutoScrollableInfiniteCarouselCollectionView) -> Int {
+        banners.count
+    }
+
+    func collectionView(
+        _ collectionView: AutoScrollableInfiniteCarouselCollectionView,
+        cellForItemAt index: Int,
+        dequeueAt indexPath: IndexPath
+    ) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: BannerCollectionViewCell.identifier, for: indexPath) as? BannerCollectionViewCell else {
+            return UICollectionViewCell()
+        }
+        cell.configure(banners[index])
+        return cell
+    }
+
+    func collectionView(
+        _ collectionView: AutoScrollableInfiniteCarouselCollectionView,
+        didSelectItemAt index: Int
+    ) {
+        onBannerTap(banners[index])
+    }
+
+    func collectionView(
+        _ collectionView: AutoScrollableInfiniteCarouselCollectionView,
+        didMoveToItemAt index: Int,
+        isUserInitiated: Bool
+    ) {
+        onPageChanged(index, banners.count)
+        if isUserInitiated {
+            onBannerSwiped(banners[index])
+        }
+    }
+}

--- a/Koin/Presentation/NewHome/Home/Subviews/BannerView/NewBannerViewController.swift
+++ b/Koin/Presentation/NewHome/Home/Subviews/BannerView/NewBannerViewController.swift
@@ -50,6 +50,7 @@ final class NewBannerViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         configureView()
+        setAddTargets()
     }
 
     // MARK: - Public

--- a/Koin/Presentation/NewHome/Home/Subviews/BannerView/NewBannerViewController.swift
+++ b/Koin/Presentation/NewHome/Home/Subviews/BannerView/NewBannerViewController.swift
@@ -1,0 +1,176 @@
+//
+//  NewBannerViewController.swift
+//  koin
+//
+//  Created by 홍기정 on 6/20/26.
+//
+
+import SnapKit
+import Then
+import UIKit
+
+final class NewBannerViewController: UIViewController {
+    
+    // MARK: - Properties
+    private let onBannerTap: (Banner) -> Void
+    private let onLogEvent: (EventLabelType, EventParameter.EventCategory, Any) -> Void
+    
+    // MARK: - UI Components
+    private let contentView = UIView()
+    private let noShowButton = UIButton()
+    private let closeButton = UIButton()
+    private lazy var collectionView = NewBannerCollectionView(
+        onBannerTap: { [weak self] banner in
+            self?.onBannerTap(banner)
+        },
+        onPageChanged: { [weak self] index, totalCount in
+            self?.setCountLabel(index: index, totalCount: totalCount)
+        },
+        onBannerSwiped: { [weak self] banner in
+            self?.onLogEvent(EventParameter.EventLabel.Campus.mainNextModal, .swipe, banner.title)
+        }
+    )
+    private let countLabel = UILabel()
+
+    // MARK: - Initializer
+    init(
+        onBannerTap: @escaping (Banner) -> Void,
+        onLogEvent: @escaping (EventLabelType, EventParameter.EventCategory, Any) -> Void
+    ) {
+        self.onBannerTap = onBannerTap
+        self.onLogEvent = onLogEvent
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Life Cycle
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureView()
+    }
+
+    // MARK: - Public
+    func setBanners(_ banners: [Banner]) {
+        collectionView.setBanners(banners)
+    }
+}
+
+extension NewBannerViewController {
+    
+    private func setAddTargets() {
+        noShowButton.addTarget(self, action: #selector(noShowButtonTapped), for: .touchUpInside)
+        closeButton.addTarget(self, action: #selector(closeButtonTapped), for: .touchUpInside)
+    }
+    
+    @objc private func noShowButtonTapped() {
+        dismiss(animated: true)
+        UserDefaults.standard.set(Date(), forKey: "noShowBanner")
+        
+        if let title = collectionView.currentTitle {
+            onLogEvent(EventParameter.EventLabel.Campus.mainModalHide7d, .click, title)
+        }
+    }
+
+    @objc private func closeButtonTapped() {
+        dismiss(animated: true)
+        
+        if let title = collectionView.currentTitle {
+            onLogEvent(EventParameter.EventLabel.Campus.mainModalClose, .click, title)
+        }
+    }
+}
+
+extension NewBannerViewController {
+    
+    private func setCountLabel(index: Int, totalCount: Int) {
+        let text = "\(index + 1)/\(totalCount)"
+        let attributedString = NSMutableAttributedString(string: text)
+        guard let slashRange = text.range(of: "/") else {
+            countLabel.attributedText = attributedString
+            return
+        }
+
+        let slashLocation = text.distance(from: text.startIndex, to: slashRange.lowerBound)
+        attributedString.addAttribute(
+            .foregroundColor,
+            value: UIColor.white,
+            range: NSRange(location: 0, length: slashLocation)
+        )
+        attributedString.addAttribute(
+            .foregroundColor,
+            value: UIColor.appColor(.neutral400),
+            range: NSRange(location: slashLocation, length: text.count - slashLocation)
+        )
+        countLabel.attributedText = attributedString
+    }
+}
+
+
+extension NewBannerViewController {
+    
+    private func configureView() {
+        setUpStyles()
+        setUpLayouts()
+        setUpConstraints()
+    }
+    
+    private func setUpStyles() {
+        view.backgroundColor = UIColor.appColor(.neutral800).withAlphaComponent(0.7)
+        contentView.backgroundColor = .white
+        contentView.layer.cornerRadius = 8
+        contentView.layer.masksToBounds = true
+        
+        noShowButton.titleLabel?.font = UIFont.appFont(.pretendardRegular, size: 14)
+        noShowButton.setTitleColor(UIColor.appColor(.neutral500), for: .normal)
+        noShowButton.setTitle("일주일 동안 그만 보기", for: .normal)
+        
+        closeButton.titleLabel?.font = UIFont.appFont(.pretendardRegular, size: 14)
+        closeButton.setTitleColor(UIColor.appColor(.neutral800), for: .normal)
+        closeButton.setTitle("닫기", for: .normal)
+        
+        countLabel.backgroundColor = .black.withAlphaComponent(0.5)
+        countLabel.font = UIFont.appFont(.pretendardRegular, size: 14)
+        countLabel.textAlignment = .center
+        countLabel.layer.cornerRadius = 8
+        countLabel.layer.masksToBounds = true
+    }
+    
+    private func setUpLayouts() {
+        view.addSubview(contentView)
+        [noShowButton, closeButton, collectionView, countLabel].forEach {
+            contentView.addSubview($0)
+        }
+    }
+    
+    private func setUpConstraints() {
+        contentView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        noShowButton.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(13)
+            $0.leading.equalToSuperview().offset(22.5)
+            $0.width.equalTo(120)
+            $0.height.equalTo(22)
+        }
+        closeButton.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(13)
+            $0.trailing.equalToSuperview().offset(-22.5)
+            $0.width.equalTo(25)
+            $0.height.equalTo(22)
+        }
+        collectionView.snp.makeConstraints {
+            $0.top.equalTo(closeButton.snp.bottom).offset(13)
+            $0.horizontalEdges.equalToSuperview()
+            $0.height.equalTo(293)
+        }
+        countLabel.snp.makeConstraints {
+            $0.top.equalTo(collectionView.snp.top).offset(8)
+            $0.trailing.equalToSuperview().offset(-10)
+            $0.width.equalTo(50)
+            $0.height.equalTo(20)
+        }
+    }
+}

--- a/koin.xcodeproj/project.pbxproj
+++ b/koin.xcodeproj/project.pbxproj
@@ -145,6 +145,8 @@
 		7C61D35B2F23CF1A005FAC3A /* FetchLostItemStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C61D35A2F23CF1A005FAC3A /* FetchLostItemStats.swift */; };
 		7C61D35F2F24000C005FAC3A /* LostItemDataButtonsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C61D35E2F24000C005FAC3A /* LostItemDataButtonsView.swift */; };
 		7C61D3632F242D8D005FAC3A /* AddLostItemHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C61D3622F242D8D005FAC3A /* AddLostItemHeaderView.swift */; };
+		7C65FDC32FE69262007831CE /* NewBannerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C65FDC22FE69262007831CE /* NewBannerViewController.swift */; };
+		7C65FDC52FE69279007831CE /* NewBannerCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C65FDC42FE69279007831CE /* NewBannerCollectionView.swift */; };
 		7C65FDC72FE69A00007831CE /* AutoScrollableInfiniteCarouselCollectionViewProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C65FDC62FE69A00007831CE /* AutoScrollableInfiniteCarouselCollectionViewProtocol.swift */; };
 		7C65FDC92FE69A00007831CE /* AutoScrollableInfiniteCarouselCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C65FDC82FE69A00007831CE /* AutoScrollableInfiniteCarouselCollectionView.swift */; };
 		7C6790322FCC00150045E163 /* PopLoggable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C6790312FCC00150045E163 /* PopLoggable.swift */; };
@@ -1144,6 +1146,8 @@
 		7C61D35A2F23CF1A005FAC3A /* FetchLostItemStats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchLostItemStats.swift; sourceTree = "<group>"; };
 		7C61D35E2F24000C005FAC3A /* LostItemDataButtonsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LostItemDataButtonsView.swift; sourceTree = "<group>"; };
 		7C61D3622F242D8D005FAC3A /* AddLostItemHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddLostItemHeaderView.swift; sourceTree = "<group>"; };
+		7C65FDC22FE69262007831CE /* NewBannerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewBannerViewController.swift; sourceTree = "<group>"; };
+		7C65FDC42FE69279007831CE /* NewBannerCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewBannerCollectionView.swift; sourceTree = "<group>"; };
 		7C65FDC62FE69A00007831CE /* AutoScrollableInfiniteCarouselCollectionViewProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoScrollableInfiniteCarouselCollectionViewProtocol.swift; sourceTree = "<group>"; };
 		7C65FDC82FE69A00007831CE /* AutoScrollableInfiniteCarouselCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoScrollableInfiniteCarouselCollectionView.swift; sourceTree = "<group>"; };
 		7C6790312FCC00150045E163 /* PopLoggable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopLoggable.swift; sourceTree = "<group>"; };
@@ -2179,6 +2183,7 @@
 		7C457B172FCE1BA80011D338 /* Subviews */ = {
 			isa = PBXGroup;
 			children = (
+				7C65FDC12FE69250007831CE /* BannerView */,
 				7C457B152FCE1BA80011D338 /* HomeHeaderView.swift */,
 				7C457B0A2FCE1BA80011D338 /* DiningView */,
 				7C457B122FCE1BA80011D338 /* MobilityView */,
@@ -2469,6 +2474,15 @@
 				7C61D3362F21FADF005FAC3A /* EditLostItemViewController.swift */,
 			);
 			path = EditLostItem;
+			sourceTree = "<group>";
+		};
+		7C65FDC12FE69250007831CE /* BannerView */ = {
+			isa = PBXGroup;
+			children = (
+				7C65FDC22FE69262007831CE /* NewBannerViewController.swift */,
+				7C65FDC42FE69279007831CE /* NewBannerCollectionView.swift */,
+			);
+			path = BannerView;
 			sourceTree = "<group>";
 		};
 		7C65FDCA2FE69A00007831CE /* AutoScrollableInfiniteCarouselCollectionView */ = {
@@ -5770,6 +5784,7 @@
 				D2BD36982BAA02E100FAE609 /* RefreshTokenResponse.swift in Sources */,
 				D215725E2CEDD2BD0061E725 /* FetchLectureUseCase.swift in Sources */,
 				D20AB9412C550746006BC684 /* RevokeUseCase.swift in Sources */,
+				7C65FDC32FE69262007831CE /* NewBannerViewController.swift in Sources */,
 				7C65FDC72FE69A00007831CE /* AutoScrollableInfiniteCarouselCollectionViewProtocol.swift in Sources */,
 				D223D6192D9C0EFC00C29BE6 /* BannerDTO.swift in Sources */,
 				833D9C222C6B4F6E00982145 /* NoticeListDTO.swift in Sources */,
@@ -6196,6 +6211,7 @@
 				7CED920F2EF2D1F900457128 /* NoticeKeywordCollectionViewCell.swift in Sources */,
 				7CED92102EF2D1F900457128 /* RegisterFormViewModel.swift in Sources */,
 				7CED92112EF2D1F900457128 /* AddDirectCollectionView.swift in Sources */,
+				7C65FDC52FE69279007831CE /* NewBannerCollectionView.swift in Sources */,
 				7C65FDC92FE69A00007831CE /* AutoScrollableInfiniteCarouselCollectionView.swift in Sources */,
 				7CED92122EF2D1F900457128 /* SortTypeBottomSheetCell.swift in Sources */,
 				7CED92132EF2D1F900457128 /* SettingsViewController.swift in Sources */,

--- a/koin.xcodeproj/project.pbxproj
+++ b/koin.xcodeproj/project.pbxproj
@@ -145,6 +145,8 @@
 		7C61D35B2F23CF1A005FAC3A /* FetchLostItemStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C61D35A2F23CF1A005FAC3A /* FetchLostItemStats.swift */; };
 		7C61D35F2F24000C005FAC3A /* LostItemDataButtonsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C61D35E2F24000C005FAC3A /* LostItemDataButtonsView.swift */; };
 		7C61D3632F242D8D005FAC3A /* AddLostItemHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C61D3622F242D8D005FAC3A /* AddLostItemHeaderView.swift */; };
+		7C65FDC72FE69A00007831CE /* AutoScrollableInfiniteCarouselCollectionViewProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C65FDC62FE69A00007831CE /* AutoScrollableInfiniteCarouselCollectionViewProtocol.swift */; };
+		7C65FDC92FE69A00007831CE /* AutoScrollableInfiniteCarouselCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C65FDC82FE69A00007831CE /* AutoScrollableInfiniteCarouselCollectionView.swift */; };
 		7C6790322FCC00150045E163 /* PopLoggable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C6790312FCC00150045E163 /* PopLoggable.swift */; };
 		7C6790842FCC48A60045E163 /* UIViewController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C67907E2FCC48A60045E163 /* UIViewController+.swift */; };
 		7C6790852FCC48A60045E163 /* UIViewController+ToastMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C6790822FCC48A60045E163 /* UIViewController+ToastMessage.swift */; };
@@ -1142,6 +1144,8 @@
 		7C61D35A2F23CF1A005FAC3A /* FetchLostItemStats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchLostItemStats.swift; sourceTree = "<group>"; };
 		7C61D35E2F24000C005FAC3A /* LostItemDataButtonsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LostItemDataButtonsView.swift; sourceTree = "<group>"; };
 		7C61D3622F242D8D005FAC3A /* AddLostItemHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddLostItemHeaderView.swift; sourceTree = "<group>"; };
+		7C65FDC62FE69A00007831CE /* AutoScrollableInfiniteCarouselCollectionViewProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoScrollableInfiniteCarouselCollectionViewProtocol.swift; sourceTree = "<group>"; };
+		7C65FDC82FE69A00007831CE /* AutoScrollableInfiniteCarouselCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoScrollableInfiniteCarouselCollectionView.swift; sourceTree = "<group>"; };
 		7C6790312FCC00150045E163 /* PopLoggable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopLoggable.swift; sourceTree = "<group>"; };
 		7C6790682FCC48A60045E163 /* Date+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+.swift"; sourceTree = "<group>"; };
 		7C6790692FCC48A60045E163 /* Int+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Int+.swift"; sourceTree = "<group>"; };
@@ -2465,6 +2469,15 @@
 				7C61D3362F21FADF005FAC3A /* EditLostItemViewController.swift */,
 			);
 			path = EditLostItem;
+			sourceTree = "<group>";
+		};
+		7C65FDCA2FE69A00007831CE /* AutoScrollableInfiniteCarouselCollectionView */ = {
+			isa = PBXGroup;
+			children = (
+				7C65FDC62FE69A00007831CE /* AutoScrollableInfiniteCarouselCollectionViewProtocol.swift */,
+				7C65FDC82FE69A00007831CE /* AutoScrollableInfiniteCarouselCollectionView.swift */,
+			);
+			path = AutoScrollableInfiniteCarouselCollectionView;
 			sourceTree = "<group>";
 		};
 		7C67906C2FCC48A60045E163 /* Common */ = {
@@ -4984,6 +4997,7 @@
 				D891F25E2E45DC9D006D1F41 /* TrackPaddedSlider.swift */,
 				7C61D3502F22B344005FAC3A /* ExtendedTouchAreaView.swift */,
 				B608F0E52EB5DC2C0006F355 /* OrderHistoryUIComponents */,
+				7C65FDCA2FE69A00007831CE /* AutoScrollableInfiniteCarouselCollectionView */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -5756,6 +5770,7 @@
 				D2BD36982BAA02E100FAE609 /* RefreshTokenResponse.swift in Sources */,
 				D215725E2CEDD2BD0061E725 /* FetchLectureUseCase.swift in Sources */,
 				D20AB9412C550746006BC684 /* RevokeUseCase.swift in Sources */,
+				7C65FDC72FE69A00007831CE /* AutoScrollableInfiniteCarouselCollectionViewProtocol.swift in Sources */,
 				D223D6192D9C0EFC00C29BE6 /* BannerDTO.swift in Sources */,
 				833D9C222C6B4F6E00982145 /* NoticeListDTO.swift in Sources */,
 				7C372F1E2F1CD8FB00149729 /* LostItemDataHeaderView.swift in Sources */,
@@ -6181,6 +6196,7 @@
 				7CED920F2EF2D1F900457128 /* NoticeKeywordCollectionViewCell.swift in Sources */,
 				7CED92102EF2D1F900457128 /* RegisterFormViewModel.swift in Sources */,
 				7CED92112EF2D1F900457128 /* AddDirectCollectionView.swift in Sources */,
+				7C65FDC92FE69A00007831CE /* AutoScrollableInfiniteCarouselCollectionView.swift in Sources */,
 				7CED92122EF2D1F900457128 /* SortTypeBottomSheetCell.swift in Sources */,
 				7CED92132EF2D1F900457128 /* SettingsViewController.swift in Sources */,
 				7CED92142EF2D1F900457128 /* LandCollectionViewCell.swift in Sources */,


### PR DESCRIPTION
## #️⃣연관된 이슈

- #464 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

홈화면 배너 작업입니다.
1. 자동 스크롤 무한 캐러셀 콜랙션뷰
    - 기존 배너에서 사용되던 콜렉션뷰의 동작에 오류가 발생했습니다. (마지막 페이지로 스크롤 시 바로 첫번째 페이지로 돌아감, 마지막 페이지에서 다음 페이지로 스크롤시 동작이 꼬임 등)
    - 재사용할 수 있는 자동 스크롤 무한 캐러셀 콜렉션뷰를 새로 만들었습니다.

2. 홈화면 배너
    - 자동 스크롤 무한 캐러셀 콜렉션뷰를 채택하는 newBannerCollectionView를 만들었습니다.
    - 기존의 viewModel 주입, publisher 구독/발행 대신, 클로저 주입 방식으로 변경했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added auto-scrolling promotional banner carousel to home screen with tap tracking
  * Users can dismiss banners with close button or "hide for 7 days" option
  * Banner taps support navigation to various app sections with version validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->