### PR TITLE
fix: 시간표 UI 버그 수정

### DIFF
--- a/Koin/Presentation/NewHome/Profile/Subviews/TimeTableView/Subviews/TimeTableLectureContainerView.swift
+++ b/Koin/Presentation/NewHome/Profile/Subviews/TimeTableView/Subviews/TimeTableLectureContainerView.swift
@@ -9,13 +9,13 @@ import SwiftUI
 
 enum TimeTableRow: Identifiable {
     case empty(at: Int)
-    case some(at: Int, LectureDataWrapper)
+    case some(at: Int, LectureDataWrapper, times: CGFloat = 1)
     
     var id: Int {
         switch self {
         case .empty(let row):
             return row
-        case .some(let row, _):
+        case .some(let row, _, _):
             return row
         }
     }
@@ -40,13 +40,13 @@ struct TimeTableLectureContainerView: View {
                 case .empty:
                     TimeTableEmptyLectureView()
                         .frame(height: TimeTableView.Layout.timeHeight)
-                case .some(_, let wrapper):
+                case .some(_, let wrapper, let times):
                     TimeTableLectureView(
                         headerColor: wrapper.header,
                         bodyColor: wrapper.body,
                         lecture: wrapper.lecture
                     )
-                    .frame(height: TimeTableView.Layout.timeHeight * wrapper.hours)
+                    .frame(height: TimeTableView.Layout.timeHeight * times)
                 }
             }
         }
@@ -83,12 +83,15 @@ extension TimeTableLectureContainerView {
     
     private func mergeConsecutiveRows(_ wrappers: [TimeTableRow]) -> [TimeTableRow] {
         wrappers.reduce(into: [TimeTableRow]()) { (result, newRow) in
-            if let lastRow = result.last,
-               case .some(_, let lastWrapper) = lastRow,
-               case .some(_, let newWrapper) = newRow,
-               lastWrapper.lecture.id != newWrapper.lecture.id {
-                result.append(newRow)
+            if var lastRow = result.last,
+               case let .some(row, lastWrapper, times) = lastRow,
+               case .some(_, let newWrapper, _) = newRow,
+               lastWrapper.lecture.id == newWrapper.lecture.id {
+                lastRow = TimeTableRow.some(at: row, lastWrapper, times: times + 1)
+                result[result.count - 1] = lastRow
+                return
             }
+            result.append(newRow)
         }
     }
 }

--- a/Koin/Presentation/NewHome/Profile/Subviews/TimeTableView/TimeTableView.swift
+++ b/Koin/Presentation/NewHome/Profile/Subviews/TimeTableView/TimeTableView.swift
@@ -11,7 +11,6 @@ struct LectureDataWrapper: Identifiable {
     let lecture: LectureData
     let header: TimetableColorAsset
     let body: TimetableColorAsset
-    let hours: CGFloat
     
     let id: Int
     
@@ -25,7 +24,6 @@ struct LectureDataWrapper: Identifiable {
         self.body = body
         
         self.id = lecture.id
-        self.hours = CGFloat(lecture.classTime.count)
     }
 }
 
@@ -73,6 +71,7 @@ struct TimeTableView: View {
     ) {
         self.timeTableTapped = timeTableTapped
         self.wrappers = splitInDays(makeWrapper(lectures))
+        print(wrappers)
     }
     
     // MARK: - Body


### PR DESCRIPTION
## #️⃣연관된 이슈

- #482 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

18시 이후 수업이 존재할 경우 해당 수업 View의 세로 길이가 길어지며 범위를 벗어나는 문제를 수정했습니다.
수업 시수만큼 높이를 직접 설정하는 로직을 삭제하고,
09~18시 사이에 배치할 row를 결정하는 로직에서 높이를 증가하도록 변경했습니다.


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved timetable rendering for lectures spanning multiple consecutive time slots.
  - Lecture rows now correctly reflect their full duration and maintain consistent row positioning.
  - Fixed timetable row merging so repeated lecture entries are combined and displayed with the appropriate height.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->