### PR TITLE
feat: 홈화면 리디자인 - 알림화면 진입 버튼 상태 기능 구현

### DIFF
--- a/Common/NotificationHistory/NotificationHistoryService.swift
+++ b/Common/NotificationHistory/NotificationHistoryService.swift
@@ -87,6 +87,8 @@ final class DefaultNotificationHistoryService: NotificationHistoryService {
             }
             try container.mainContext.save()
         }
+        
+        postNotificationRead()
     }
     
     func markAllAsRead() async throws {
@@ -102,6 +104,8 @@ final class DefaultNotificationHistoryService: NotificationHistoryService {
             }
             try container.mainContext.save()
         }
+        
+        postNotificationRead()
     }
     
     // MARK: - Delete
@@ -116,6 +120,8 @@ final class DefaultNotificationHistoryService: NotificationHistoryService {
             })
             try container.mainContext.save()
         }
+        
+        postNotificationRead()
     }
     
     func deleteAll() async throws {
@@ -127,6 +133,8 @@ final class DefaultNotificationHistoryService: NotificationHistoryService {
             try container.mainContext.delete(model: NotificationRecord.self)
             try container.mainContext.save()
         }
+        
+        postNotificationRead()
     }
 }
 
@@ -146,5 +154,14 @@ extension DefaultNotificationHistoryService {
             })
             try container.mainContext.save()
         }
+    }
+}
+
+extension DefaultNotificationHistoryService {
+    private func postNotificationRead() {
+        NotificationCenter.default.post(
+            name: NSNotification.Name("Notification Read"),
+            object: nil
+        )
     }
 }

--- a/Koin/Apps/AppDelegate.swift
+++ b/Koin/Apps/AppDelegate.swift
@@ -70,6 +70,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         _ center: UNUserNotificationCenter,
         willPresent notification: UNNotification
     ) async -> UNNotificationPresentationOptions {
+        // 푸시 알림 도착 전역에 알림 (HomeTabbar에서 관찰)
+        NotificationCenter.default.post(
+            name: NSNotification.Name("Notification Sent"),
+            object: nil
+        )
         // 푸시 알림 옵션 반환
         return [[.banner, .list, .sound]]
     }

--- a/Koin/Apps/SceneDelegate.swift
+++ b/Koin/Apps/SceneDelegate.swift
@@ -186,10 +186,10 @@ extension SceneDelegate {
         let profileViewController = makeProfileHostingController()
         
         let logAnalyticsEventUseCase = DefaultLogAnalyticsEventUseCase(repository: GA4AnalyticsRepository(service: GA4AnalyticsService()))
-        let fetchNotificationHistoryUseCase = DefaultFetchNotificationHistoryUseCase(notificationHistoryRepository: DefaultNotificationHistoryRepository(service: DefaultNotificationHistoryService()))
+        let checkHasUnreadNotificationHistoryUseCase = DefaultCheckHasUnreadNotificationHistoryUseCase(repository: DefaultNotificationHistoryRepository(service: DefaultNotificationHistoryService()))
         let viewModel = HomeTabBarViewModel(
             logAnalyticsEventUseCase: logAnalyticsEventUseCase,
-            fetchNotificationHistoryUseCase: fetchNotificationHistoryUseCase
+            checkHasUnreadNotificationHistoryUseCase: checkHasUnreadNotificationHistoryUseCase
         )
 
         return HomeTabBarController(

--- a/Koin/Apps/SceneDelegate.swift
+++ b/Koin/Apps/SceneDelegate.swift
@@ -186,7 +186,11 @@ extension SceneDelegate {
         let profileViewController = makeProfileHostingController()
         
         let logAnalyticsEventUseCase = DefaultLogAnalyticsEventUseCase(repository: GA4AnalyticsRepository(service: GA4AnalyticsService()))
-        let viewModel = HomeTabBarViewModel(logAnalyticsEventUseCase: logAnalyticsEventUseCase)
+        let fetchNotificationHistoryUseCase = DefaultFetchNotificationHistoryUseCase(notificationHistoryRepository: DefaultNotificationHistoryRepository(service: DefaultNotificationHistoryService()))
+        let viewModel = HomeTabBarViewModel(
+            logAnalyticsEventUseCase: logAnalyticsEventUseCase,
+            fetchNotificationHistoryUseCase: fetchNotificationHistoryUseCase
+        )
 
         return HomeTabBarController(
             items: [

--- a/Koin/Domain/UseCase/NewHome/CheckHasUnreadNotificationHistoryUseCase.swift
+++ b/Koin/Domain/UseCase/NewHome/CheckHasUnreadNotificationHistoryUseCase.swift
@@ -1,5 +1,5 @@
 //
-//  CheckUnreadNotificationHistoryUseCase.swift
+//  CheckHasUnreadNotificationHistoryUseCase.swift
 //  koin
 //
 //  Created by 홍기정 on 7/14/26.

--- a/Koin/Domain/UseCase/NewHome/CheckUnreadNotificationHistoryUseCase.swift
+++ b/Koin/Domain/UseCase/NewHome/CheckUnreadNotificationHistoryUseCase.swift
@@ -1,0 +1,28 @@
+//
+//  CheckUnreadNotificationHistoryUseCase.swift
+//  koin
+//
+//  Created by 홍기정 on 7/14/26.
+//
+
+import Foundation
+
+protocol CheckHasUnreadNotificationHistoryUseCase {
+    func execute() async throws -> Bool
+}
+
+final class DefaultCheckHasUnreadNotificationHistoryUseCase: CheckHasUnreadNotificationHistoryUseCase {
+    
+    private let repository: NotificationHistoryRepository
+    
+    init(repository: NotificationHistoryRepository) {
+        self.repository = repository
+    }
+    
+    func execute() async throws -> Bool {
+        do {
+            let unreads = try await repository.fetchAll().filter { !$0.isRead }
+            return unreads.isEmpty ? false : true
+        }
+    }
+}

--- a/Koin/Presentation/Home/Home/SubViews/ForceModifyUserViewController.swift
+++ b/Koin/Presentation/Home/Home/SubViews/ForceModifyUserViewController.swift
@@ -80,17 +80,17 @@ extension ForceModifyUserViewController {
     }
     
     private func makeHomeTabBarController() -> HomeTabBarController {
-        let homeRootView = makeHomeView()
-        let homeViewController = HomeHostingController(rootView: homeRootView)
-
-        let logAnalyticsEventUseCase = DefaultLogAnalyticsEventUseCase(repository: GA4AnalyticsRepository(service: GA4AnalyticsService()))
-        let categoryRootView = CategoryView(viewModel: CategoryViewModel(logAnalyticsEventUseCase: logAnalyticsEventUseCase))
-        let categoryViewController = CategoryHostingController(rootView: categoryRootView)
-
+        let homeViewController = makeHomeHostingController()
+        let categoryViewController = makeCategoryHostingController()
         let noticeViewController = makeNoticeListViewController()
-        let profileViewController = UIViewController()
+        let profileViewController = makeProfileHostingController()
         
-        let viewModel = HomeTabBarViewModel(logAnalyticsEventUseCase: logAnalyticsEventUseCase)
+        let logAnalyticsEventUseCase = DefaultLogAnalyticsEventUseCase(repository: GA4AnalyticsRepository(service: GA4AnalyticsService()))
+        let fetchNotificationHistoryUseCase = DefaultFetchNotificationHistoryUseCase(notificationHistoryRepository: DefaultNotificationHistoryRepository(service: DefaultNotificationHistoryService()))
+        let viewModel = HomeTabBarViewModel(
+            logAnalyticsEventUseCase: logAnalyticsEventUseCase,
+            fetchNotificationHistoryUseCase: fetchNotificationHistoryUseCase
+        )
 
         return HomeTabBarController(
             items: [
@@ -103,7 +103,7 @@ extension ForceModifyUserViewController {
         )
     }
 
-    private func makeHomeView() -> HomeView {
+    private func makeHomeHostingController() -> UIViewController {
         let callVanRepository = DefaultCallVanRepository(service: DefaultCallVanService())
         let shopRepository = DefaultShopRepository(service: DefaultShopService())
         let coreRepository = DefaultCoreRepository(service: DefaultCoreService())
@@ -141,7 +141,14 @@ extension ForceModifyUserViewController {
             logAnalyticsEventUseCase: logAnalyticsEventUseCase,
             fetchBannerUseCase: DefaultFetchBannerUseCase(coreRepository: coreRepository)
         )
-        return HomeView(viewModel: viewModel)
+        let homeView = HomeView(viewModel: viewModel)
+        return HomeHostingController(rootView: homeView)
+    }
+    
+    private func makeCategoryHostingController() -> UIViewController {
+        let logAnalyticsEventUseCase = DefaultLogAnalyticsEventUseCase(repository: GA4AnalyticsRepository(service: GA4AnalyticsService()))
+        let categoryRootView = CategoryView(viewModel: CategoryViewModel(logAnalyticsEventUseCase: logAnalyticsEventUseCase))
+        return CategoryHostingController(rootView: categoryRootView)
     }
     
     private func makeNoticeListViewController() -> UIViewController {
@@ -159,7 +166,26 @@ extension ForceModifyUserViewController {
         )
         return NoticeListViewController(viewModel: viewModel)
     }
-
+    
+    private func makeProfileHostingController() -> UIViewController {
+        let timeTableRepository = DefaultTimetableRepository(service: DefaultTimetableService())
+        let logAnalyticsEventUseCase = DefaultLogAnalyticsEventUseCase(repository: GA4AnalyticsRepository(service: GA4AnalyticsService()))
+        let deleteDeviceTokenUseCase = DefaultDeleteDeviceTokenUseCase(repository: DefaultNotiRepository(service: DefaultNotiService()))
+        let fetchUserDataUseCase = DefaultFetchUserDataUseCase(userRepository: DefaultUserRepository(service: DefaultUserService()))
+        let fetchMainFrameUseCase = DefaultFetchMainFrameUseCase(
+            fetchFramesUseCase: DefaultFetchFramesUseCase(timetableRepository: timeTableRepository),
+            fetchFrameUseCase: DefaultFetchFrameUseCase(timetableRepository: timeTableRepository),
+            fetchLectureUseCase: DefaultFetchLectureUseCase(timetableRepository: timeTableRepository)
+        )
+        let profileViewModel = ProfileViewModel(
+            logAnalyticsEventUseCase: logAnalyticsEventUseCase,
+            deleteDeviceTokenUseCase: deleteDeviceTokenUseCase,
+            fetchUserDataUseCase: fetchUserDataUseCase,
+            fetchMainFrameUseCase: fetchMainFrameUseCase
+        )
+        let profileView = ProfileView(viewModel: profileViewModel)
+        return ProfileHostingController(rootView: profileView)
+    }
 }
 
 extension ForceModifyUserViewController {

--- a/Koin/Presentation/Home/Home/SubViews/ForceModifyUserViewController.swift
+++ b/Koin/Presentation/Home/Home/SubViews/ForceModifyUserViewController.swift
@@ -86,10 +86,10 @@ extension ForceModifyUserViewController {
         let profileViewController = makeProfileHostingController()
         
         let logAnalyticsEventUseCase = DefaultLogAnalyticsEventUseCase(repository: GA4AnalyticsRepository(service: GA4AnalyticsService()))
-        let fetchNotificationHistoryUseCase = DefaultFetchNotificationHistoryUseCase(notificationHistoryRepository: DefaultNotificationHistoryRepository(service: DefaultNotificationHistoryService()))
+        let checkHasUnreadNotificationHistoryUseCase = DefaultCheckHasUnreadNotificationHistoryUseCase(repository: DefaultNotificationHistoryRepository(service: DefaultNotificationHistoryService()))
         let viewModel = HomeTabBarViewModel(
             logAnalyticsEventUseCase: logAnalyticsEventUseCase,
-            fetchNotificationHistoryUseCase: fetchNotificationHistoryUseCase
+            checkHasUnreadNotificationHistoryUseCase: checkHasUnreadNotificationHistoryUseCase
         )
 
         return HomeTabBarController(

--- a/Koin/Presentation/Login/FindId/ViewControllers/FoundIdViewController.swift
+++ b/Koin/Presentation/Login/FindId/ViewControllers/FoundIdViewController.swift
@@ -115,17 +115,17 @@ extension FoundIdViewController {
     }
     
     private func makeHomeTabBarController() -> HomeTabBarController {
-        let homeRootView = makeHomeView()
-        let homeViewController = HomeHostingController(rootView: homeRootView)
-
-        let logAnalyticsEventUseCase = DefaultLogAnalyticsEventUseCase(repository: GA4AnalyticsRepository(service: GA4AnalyticsService()))
-        let categoryRootView = CategoryView(viewModel: CategoryViewModel(logAnalyticsEventUseCase: logAnalyticsEventUseCase))
-        let categoryViewController = CategoryHostingController(rootView: categoryRootView)
-
+        let homeViewController = makeHomeHostingController()
+        let categoryViewController = makeCategoryHostingController()
         let noticeViewController = makeNoticeListViewController()
-        let profileViewController = UIViewController()
+        let profileViewController = makeProfileHostingController()
         
-        let viewModel = HomeTabBarViewModel(logAnalyticsEventUseCase: logAnalyticsEventUseCase)
+        let logAnalyticsEventUseCase = DefaultLogAnalyticsEventUseCase(repository: GA4AnalyticsRepository(service: GA4AnalyticsService()))
+        let fetchNotificationHistoryUseCase = DefaultFetchNotificationHistoryUseCase(notificationHistoryRepository: DefaultNotificationHistoryRepository(service: DefaultNotificationHistoryService()))
+        let viewModel = HomeTabBarViewModel(
+            logAnalyticsEventUseCase: logAnalyticsEventUseCase,
+            fetchNotificationHistoryUseCase: fetchNotificationHistoryUseCase
+        )
 
         return HomeTabBarController(
             items: [
@@ -138,7 +138,7 @@ extension FoundIdViewController {
         )
     }
 
-    private func makeHomeView() -> HomeView {
+    private func makeHomeHostingController() -> UIViewController {
         let callVanRepository = DefaultCallVanRepository(service: DefaultCallVanService())
         let shopRepository = DefaultShopRepository(service: DefaultShopService())
         let coreRepository = DefaultCoreRepository(service: DefaultCoreService())
@@ -176,7 +176,14 @@ extension FoundIdViewController {
             logAnalyticsEventUseCase: logAnalyticsEventUseCase,
             fetchBannerUseCase: DefaultFetchBannerUseCase(coreRepository: coreRepository)
         )
-        return HomeView(viewModel: viewModel)
+        let homeView = HomeView(viewModel: viewModel)
+        return HomeHostingController(rootView: homeView)
+    }
+    
+    private func makeCategoryHostingController() -> UIViewController {
+        let logAnalyticsEventUseCase = DefaultLogAnalyticsEventUseCase(repository: GA4AnalyticsRepository(service: GA4AnalyticsService()))
+        let categoryRootView = CategoryView(viewModel: CategoryViewModel(logAnalyticsEventUseCase: logAnalyticsEventUseCase))
+        return CategoryHostingController(rootView: categoryRootView)
     }
     
     private func makeNoticeListViewController() -> UIViewController {
@@ -194,7 +201,26 @@ extension FoundIdViewController {
         )
         return NoticeListViewController(viewModel: viewModel)
     }
-
+    
+    private func makeProfileHostingController() -> UIViewController {
+        let timeTableRepository = DefaultTimetableRepository(service: DefaultTimetableService())
+        let logAnalyticsEventUseCase = DefaultLogAnalyticsEventUseCase(repository: GA4AnalyticsRepository(service: GA4AnalyticsService()))
+        let deleteDeviceTokenUseCase = DefaultDeleteDeviceTokenUseCase(repository: DefaultNotiRepository(service: DefaultNotiService()))
+        let fetchUserDataUseCase = DefaultFetchUserDataUseCase(userRepository: DefaultUserRepository(service: DefaultUserService()))
+        let fetchMainFrameUseCase = DefaultFetchMainFrameUseCase(
+            fetchFramesUseCase: DefaultFetchFramesUseCase(timetableRepository: timeTableRepository),
+            fetchFrameUseCase: DefaultFetchFrameUseCase(timetableRepository: timeTableRepository),
+            fetchLectureUseCase: DefaultFetchLectureUseCase(timetableRepository: timeTableRepository)
+        )
+        let profileViewModel = ProfileViewModel(
+            logAnalyticsEventUseCase: logAnalyticsEventUseCase,
+            deleteDeviceTokenUseCase: deleteDeviceTokenUseCase,
+            fetchUserDataUseCase: fetchUserDataUseCase,
+            fetchMainFrameUseCase: fetchMainFrameUseCase
+        )
+        let profileView = ProfileView(viewModel: profileViewModel)
+        return ProfileHostingController(rootView: profileView)
+    }
 }
 
 extension FoundIdViewController {

--- a/Koin/Presentation/Login/FindId/ViewControllers/FoundIdViewController.swift
+++ b/Koin/Presentation/Login/FindId/ViewControllers/FoundIdViewController.swift
@@ -121,10 +121,10 @@ extension FoundIdViewController {
         let profileViewController = makeProfileHostingController()
         
         let logAnalyticsEventUseCase = DefaultLogAnalyticsEventUseCase(repository: GA4AnalyticsRepository(service: GA4AnalyticsService()))
-        let fetchNotificationHistoryUseCase = DefaultFetchNotificationHistoryUseCase(notificationHistoryRepository: DefaultNotificationHistoryRepository(service: DefaultNotificationHistoryService()))
+        let checkHasUnreadNotificationHistoryUseCase = DefaultCheckHasUnreadNotificationHistoryUseCase(repository: DefaultNotificationHistoryRepository(service: DefaultNotificationHistoryService()))
         let viewModel = HomeTabBarViewModel(
             logAnalyticsEventUseCase: logAnalyticsEventUseCase,
-            fetchNotificationHistoryUseCase: fetchNotificationHistoryUseCase
+            checkHasUnreadNotificationHistoryUseCase: checkHasUnreadNotificationHistoryUseCase
         )
 
         return HomeTabBarController(

--- a/Koin/Presentation/Login/FindPassword/ChangePasswordSuccessViewController.swift
+++ b/Koin/Presentation/Login/FindPassword/ChangePasswordSuccessViewController.swift
@@ -88,17 +88,17 @@ extension ChangePasswordSuccessViewController {
     }
     
     private func makeHomeTabBarController() -> HomeTabBarController {
-        let homeRootView = makeHomeView()
-        let homeViewController = HomeHostingController(rootView: homeRootView)
-
-        let logAnalyticsEventUseCase = DefaultLogAnalyticsEventUseCase(repository: GA4AnalyticsRepository(service: GA4AnalyticsService()))
-        let categoryRootView = CategoryView(viewModel: CategoryViewModel(logAnalyticsEventUseCase: logAnalyticsEventUseCase))
-        let categoryViewController = CategoryHostingController(rootView: categoryRootView)
-
+        let homeViewController = makeHomeHostingController()
+        let categoryViewController = makeCategoryHostingController()
         let noticeViewController = makeNoticeListViewController()
-        let profileViewController = UIViewController()
+        let profileViewController = makeProfileHostingController()
         
-        let viewModel = HomeTabBarViewModel(logAnalyticsEventUseCase: logAnalyticsEventUseCase)
+        let logAnalyticsEventUseCase = DefaultLogAnalyticsEventUseCase(repository: GA4AnalyticsRepository(service: GA4AnalyticsService()))
+        let fetchNotificationHistoryUseCase = DefaultFetchNotificationHistoryUseCase(notificationHistoryRepository: DefaultNotificationHistoryRepository(service: DefaultNotificationHistoryService()))
+        let viewModel = HomeTabBarViewModel(
+            logAnalyticsEventUseCase: logAnalyticsEventUseCase,
+            fetchNotificationHistoryUseCase: fetchNotificationHistoryUseCase
+        )
 
         return HomeTabBarController(
             items: [
@@ -111,7 +111,7 @@ extension ChangePasswordSuccessViewController {
         )
     }
 
-    private func makeHomeView() -> HomeView {
+    private func makeHomeHostingController() -> UIViewController {
         let callVanRepository = DefaultCallVanRepository(service: DefaultCallVanService())
         let shopRepository = DefaultShopRepository(service: DefaultShopService())
         let coreRepository = DefaultCoreRepository(service: DefaultCoreService())
@@ -149,7 +149,14 @@ extension ChangePasswordSuccessViewController {
             logAnalyticsEventUseCase: logAnalyticsEventUseCase,
             fetchBannerUseCase: DefaultFetchBannerUseCase(coreRepository: coreRepository)
         )
-        return HomeView(viewModel: viewModel)
+        let homeView = HomeView(viewModel: viewModel)
+        return HomeHostingController(rootView: homeView)
+    }
+    
+    private func makeCategoryHostingController() -> UIViewController {
+        let logAnalyticsEventUseCase = DefaultLogAnalyticsEventUseCase(repository: GA4AnalyticsRepository(service: GA4AnalyticsService()))
+        let categoryRootView = CategoryView(viewModel: CategoryViewModel(logAnalyticsEventUseCase: logAnalyticsEventUseCase))
+        return CategoryHostingController(rootView: categoryRootView)
     }
     
     private func makeNoticeListViewController() -> UIViewController {
@@ -166,6 +173,26 @@ extension ChangePasswordSuccessViewController {
             logAnalyticsEventUseCase: logAnalyticsEventUseCase
         )
         return NoticeListViewController(viewModel: viewModel)
+    }
+    
+    private func makeProfileHostingController() -> UIViewController {
+        let timeTableRepository = DefaultTimetableRepository(service: DefaultTimetableService())
+        let logAnalyticsEventUseCase = DefaultLogAnalyticsEventUseCase(repository: GA4AnalyticsRepository(service: GA4AnalyticsService()))
+        let deleteDeviceTokenUseCase = DefaultDeleteDeviceTokenUseCase(repository: DefaultNotiRepository(service: DefaultNotiService()))
+        let fetchUserDataUseCase = DefaultFetchUserDataUseCase(userRepository: DefaultUserRepository(service: DefaultUserService()))
+        let fetchMainFrameUseCase = DefaultFetchMainFrameUseCase(
+            fetchFramesUseCase: DefaultFetchFramesUseCase(timetableRepository: timeTableRepository),
+            fetchFrameUseCase: DefaultFetchFrameUseCase(timetableRepository: timeTableRepository),
+            fetchLectureUseCase: DefaultFetchLectureUseCase(timetableRepository: timeTableRepository)
+        )
+        let profileViewModel = ProfileViewModel(
+            logAnalyticsEventUseCase: logAnalyticsEventUseCase,
+            deleteDeviceTokenUseCase: deleteDeviceTokenUseCase,
+            fetchUserDataUseCase: fetchUserDataUseCase,
+            fetchMainFrameUseCase: fetchMainFrameUseCase
+        )
+        let profileView = ProfileView(viewModel: profileViewModel)
+        return ProfileHostingController(rootView: profileView)
     }
 }
 

--- a/Koin/Presentation/Login/FindPassword/ChangePasswordSuccessViewController.swift
+++ b/Koin/Presentation/Login/FindPassword/ChangePasswordSuccessViewController.swift
@@ -94,10 +94,10 @@ extension ChangePasswordSuccessViewController {
         let profileViewController = makeProfileHostingController()
         
         let logAnalyticsEventUseCase = DefaultLogAnalyticsEventUseCase(repository: GA4AnalyticsRepository(service: GA4AnalyticsService()))
-        let fetchNotificationHistoryUseCase = DefaultFetchNotificationHistoryUseCase(notificationHistoryRepository: DefaultNotificationHistoryRepository(service: DefaultNotificationHistoryService()))
+        let checkHasUnreadNotificationHistoryUseCase = DefaultCheckHasUnreadNotificationHistoryUseCase(repository: DefaultNotificationHistoryRepository(service: DefaultNotificationHistoryService()))
         let viewModel = HomeTabBarViewModel(
             logAnalyticsEventUseCase: logAnalyticsEventUseCase,
-            fetchNotificationHistoryUseCase: fetchNotificationHistoryUseCase
+            checkHasUnreadNotificationHistoryUseCase: checkHasUnreadNotificationHistoryUseCase
         )
 
         return HomeTabBarController(

--- a/Koin/Presentation/Login/Login/LoginViewController.swift
+++ b/Koin/Presentation/Login/Login/LoginViewController.swift
@@ -344,17 +344,17 @@ extension LoginViewController {
 
 extension LoginViewController {
     private func makeHomeTabBarController() -> HomeTabBarController {
-        let homeRootView = makeHomeView()
-        let homeViewController = HomeHostingController(rootView: homeRootView)
-
-        let logAnalyticsEventUseCase = DefaultLogAnalyticsEventUseCase(repository: GA4AnalyticsRepository(service: GA4AnalyticsService()))
-        let categoryRootView = CategoryView(viewModel: CategoryViewModel(logAnalyticsEventUseCase: logAnalyticsEventUseCase))
-        let categoryViewController = CategoryHostingController(rootView: categoryRootView)
-
+        let homeViewController = makeHomeHostingController()
+        let categoryViewController = makeCategoryHostingController()
         let noticeViewController = makeNoticeListViewController()
-        let profileViewController = UIViewController()
+        let profileViewController = makeProfileHostingController()
         
-        let viewModel = HomeTabBarViewModel(logAnalyticsEventUseCase: logAnalyticsEventUseCase)
+        let logAnalyticsEventUseCase = DefaultLogAnalyticsEventUseCase(repository: GA4AnalyticsRepository(service: GA4AnalyticsService()))
+        let fetchNotificationHistoryUseCase = DefaultFetchNotificationHistoryUseCase(notificationHistoryRepository: DefaultNotificationHistoryRepository(service: DefaultNotificationHistoryService()))
+        let viewModel = HomeTabBarViewModel(
+            logAnalyticsEventUseCase: logAnalyticsEventUseCase,
+            fetchNotificationHistoryUseCase: fetchNotificationHistoryUseCase
+        )
 
         return HomeTabBarController(
             items: [
@@ -367,7 +367,7 @@ extension LoginViewController {
         )
     }
 
-    private func makeHomeView() -> HomeView {
+    private func makeHomeHostingController() -> UIViewController {
         let callVanRepository = DefaultCallVanRepository(service: DefaultCallVanService())
         let shopRepository = DefaultShopRepository(service: DefaultShopService())
         let coreRepository = DefaultCoreRepository(service: DefaultCoreService())
@@ -405,7 +405,14 @@ extension LoginViewController {
             logAnalyticsEventUseCase: logAnalyticsEventUseCase,
             fetchBannerUseCase: DefaultFetchBannerUseCase(coreRepository: coreRepository)
         )
-        return HomeView(viewModel: viewModel)
+        let homeView = HomeView(viewModel: viewModel)
+        return HomeHostingController(rootView: homeView)
+    }
+    
+    private func makeCategoryHostingController() -> UIViewController {
+        let logAnalyticsEventUseCase = DefaultLogAnalyticsEventUseCase(repository: GA4AnalyticsRepository(service: GA4AnalyticsService()))
+        let categoryRootView = CategoryView(viewModel: CategoryViewModel(logAnalyticsEventUseCase: logAnalyticsEventUseCase))
+        return CategoryHostingController(rootView: categoryRootView)
     }
     
     private func makeNoticeListViewController() -> UIViewController {
@@ -423,5 +430,24 @@ extension LoginViewController {
         )
         return NoticeListViewController(viewModel: viewModel)
     }
-
+    
+    private func makeProfileHostingController() -> UIViewController {
+        let timeTableRepository = DefaultTimetableRepository(service: DefaultTimetableService())
+        let logAnalyticsEventUseCase = DefaultLogAnalyticsEventUseCase(repository: GA4AnalyticsRepository(service: GA4AnalyticsService()))
+        let deleteDeviceTokenUseCase = DefaultDeleteDeviceTokenUseCase(repository: DefaultNotiRepository(service: DefaultNotiService()))
+        let fetchUserDataUseCase = DefaultFetchUserDataUseCase(userRepository: DefaultUserRepository(service: DefaultUserService()))
+        let fetchMainFrameUseCase = DefaultFetchMainFrameUseCase(
+            fetchFramesUseCase: DefaultFetchFramesUseCase(timetableRepository: timeTableRepository),
+            fetchFrameUseCase: DefaultFetchFrameUseCase(timetableRepository: timeTableRepository),
+            fetchLectureUseCase: DefaultFetchLectureUseCase(timetableRepository: timeTableRepository)
+        )
+        let profileViewModel = ProfileViewModel(
+            logAnalyticsEventUseCase: logAnalyticsEventUseCase,
+            deleteDeviceTokenUseCase: deleteDeviceTokenUseCase,
+            fetchUserDataUseCase: fetchUserDataUseCase,
+            fetchMainFrameUseCase: fetchMainFrameUseCase
+        )
+        let profileView = ProfileView(viewModel: profileViewModel)
+        return ProfileHostingController(rootView: profileView)
+    }
 }

--- a/Koin/Presentation/Login/Login/LoginViewController.swift
+++ b/Koin/Presentation/Login/Login/LoginViewController.swift
@@ -350,10 +350,10 @@ extension LoginViewController {
         let profileViewController = makeProfileHostingController()
         
         let logAnalyticsEventUseCase = DefaultLogAnalyticsEventUseCase(repository: GA4AnalyticsRepository(service: GA4AnalyticsService()))
-        let fetchNotificationHistoryUseCase = DefaultFetchNotificationHistoryUseCase(notificationHistoryRepository: DefaultNotificationHistoryRepository(service: DefaultNotificationHistoryService()))
+        let checkHasUnreadNotificationHistoryUseCase = DefaultCheckHasUnreadNotificationHistoryUseCase(repository: DefaultNotificationHistoryRepository(service: DefaultNotificationHistoryService()))
         let viewModel = HomeTabBarViewModel(
             logAnalyticsEventUseCase: logAnalyticsEventUseCase,
-            fetchNotificationHistoryUseCase: fetchNotificationHistoryUseCase
+            checkHasUnreadNotificationHistoryUseCase: checkHasUnreadNotificationHistoryUseCase
         )
 
         return HomeTabBarController(

--- a/Koin/Presentation/NewHome/Category/CategoryHostingController.swift
+++ b/Koin/Presentation/NewHome/Category/CategoryHostingController.swift
@@ -22,12 +22,6 @@ final class CategoryHostingController: UIHostingController<CategoryView>, Hostin
     @MainActor @preconcurrency required dynamic init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
-    // MARK: - Life Cycle
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        configureNavigationBar()
-    }
 
     // MARK: - Public
     func execute(action: RootView.Action) {
@@ -53,54 +47,6 @@ final class CategoryHostingController: UIHostingController<CategoryView>, Hostin
         case .showBusiness:
             presentBusiness()
         }
-    }
-}
-
-extension CategoryHostingController {
-    
-    private func configureNavigationBar() {
-        configureNavigationBar(style: .order)
-        configureLeftBarItem()
-        configureRightBarButton()
-    }
-
-    private func configureLeftBarItem() {
-        let leftBarButtonItem = UIBarButtonItem(customView: HomeLogoView())
-        navigationItem.leftBarButtonItem = leftBarButtonItem
-    }
-
-    private func configureRightBarButton(hasDot: Bool = false) {
-        navigationItem.rightBarButtonItem = UIBarButtonItem(
-            image: .appImage(asset: hasDot ? .homeBellDot : .homeBell)?.withRenderingMode(.alwaysOriginal),
-            style: .plain,
-            target: self,
-            action: #selector(rightBarButtonTapped)
-        )
-    }
-
-    @objc private func rightBarButtonTapped() {
-        rootView.makeLogAnalyticsEvent(
-            label: EventParameter.EventLabel.Campus.notification,
-            category: .click,
-            value: "알림 아이콘")
-        navigateToNotification()
-    }
-     
-    private func navigateToNotification() {
-        let notificatioHistoryRepository = DefaultNotificationHistoryRepository(service: DefaultNotificationHistoryService())
-        let fetchNotificationHistoryUseCase = DefaultFetchNotificationHistoryUseCase(notificationHistoryRepository: notificatioHistoryRepository)
-        let deleteNotificationHistoryUseCase = DefaultDeleteNotificationHistoryUseCase(repository: notificatioHistoryRepository)
-        let updateNotificationHistoryUseCase = DefaultUpdateNotificationHistoryUseCase(repository: notificatioHistoryRepository)
-        
-        let logAnalyticsEventUseCase = DefaultLogAnalyticsEventUseCase(repository: GA4AnalyticsRepository(service: GA4AnalyticsService()))
-        let viewModel = NotificationViewModel(
-            fetchNotificationHistoryUseCase: fetchNotificationHistoryUseCase,
-            deleteNotificationHistoryUseCase: deleteNotificationHistoryUseCase,
-            updateNotificationHistoryUseCase: updateNotificationHistoryUseCase,
-            logAnalyticsEventUseCase: logAnalyticsEventUseCase
-        )
-        let viewController = NotificationViewController(viewModel: viewModel)
-        navigationController?.pushViewController(viewController, animated: true)
     }
 }
 

--- a/Koin/Presentation/NewHome/Home/HomeHostingController.swift
+++ b/Koin/Presentation/NewHome/Home/HomeHostingController.swift
@@ -22,12 +22,6 @@ final class HomeHostingController: UIHostingController<HomeView>, HostingControl
         fatalError("init(coder:) has not been implemented")
     }
     
-    // MARK: - Life Cycle
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        configureNavigationBar()
-    }
-
     // MARK: - Public
     func execute(action: RootView.Action) {
         switch action {
@@ -52,55 +46,6 @@ final class HomeHostingController: UIHostingController<HomeView>, HostingControl
         case let .showBanner(banner, isLoggedIn):
             showBanner(banner, isLoggedIn: isLoggedIn)
         }
-    }
-}
-
-extension HomeHostingController {
-    
-    private func configureNavigationBar() {
-        configureNavigationBar(style: .order)
-        configureLeftBarItem()
-        configureRightBarButton()
-    }
-
-    private func configureLeftBarItem() {
-        let leftBarButtonItem = UIBarButtonItem(customView: HomeLogoView())
-        navigationItem.leftBarButtonItem = leftBarButtonItem
-    }
-
-    private func configureRightBarButton(hasDot: Bool = false) {
-        navigationItem.rightBarButtonItem = UIBarButtonItem(
-            image: .appImage(asset: hasDot ? .homeBellDot : .homeBell)?.withRenderingMode(.alwaysOriginal),
-            style: .plain,
-            target: self,
-            action: #selector(rightBarButtonTapped)
-        )
-    }
-
-    @objc private func rightBarButtonTapped() {
-        rootView.makeLogAnalyticsEvent(
-            label: EventParameter.EventLabel.Campus.notification,
-            category: .click,
-            value: "알림 아이콘"
-        )
-        navigateToNotification()
-    }
-     
-    private func navigateToNotification() {
-        let notificatioHistoryRepository = DefaultNotificationHistoryRepository(service: DefaultNotificationHistoryService())
-        let fetchNotificationHistoryUseCase = DefaultFetchNotificationHistoryUseCase(notificationHistoryRepository: notificatioHistoryRepository)
-        let deleteNotificationHistoryUseCase = DefaultDeleteNotificationHistoryUseCase(repository: notificatioHistoryRepository)
-        let updateNotificationHistoryUseCase = DefaultUpdateNotificationHistoryUseCase(repository: notificatioHistoryRepository)
-        
-        let logAnalyticsEventUseCase = DefaultLogAnalyticsEventUseCase(repository: GA4AnalyticsRepository(service: GA4AnalyticsService()))
-        let viewModel = NotificationViewModel(
-            fetchNotificationHistoryUseCase: fetchNotificationHistoryUseCase,
-            deleteNotificationHistoryUseCase: deleteNotificationHistoryUseCase,
-            updateNotificationHistoryUseCase: updateNotificationHistoryUseCase,
-            logAnalyticsEventUseCase: logAnalyticsEventUseCase
-        )
-        let viewController = NotificationViewController(viewModel: viewModel)
-        navigationController?.pushViewController(viewController, animated: true)
     }
 }
 

--- a/Koin/Presentation/NewHome/HomeTabbar/HomeTabbarController.swift
+++ b/Koin/Presentation/NewHome/HomeTabbar/HomeTabbarController.swift
@@ -53,6 +53,7 @@ final class HomeTabBarController: UITabBarController {
         super.viewDidLoad()
         tabBar.isHidden = true
         bind()
+        setUpObserver()
         setUpViewControllers()
         if let firstTab = items.first?.tab {
             selectTab(index: firstTab.rawValue)
@@ -85,6 +86,33 @@ final class HomeTabBarController: UITabBarController {
                 case .hasUnreadNotifications(let hasUnreadNotifications):
                     self?.configureRightBarButton(hasUnreadNotifications: hasUnreadNotifications)
                 }
+            }
+            .store(in: &subscriptions)
+    }
+}
+
+extension HomeTabBarController {
+    private func setUpObserver() {
+        NotificationCenter.default.addObserver(
+            forName: NSNotification.Name("Notification Read"),
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.inputSubject.send(.checkNotification)
+        }
+        
+        NotificationCenter.default.addObserver(
+            forName: NSNotification.Name("Notification Sent"),
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.configureRightBarButton(hasUnreadNotifications: true)
+        }
+        
+        NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.inputSubject.send(.checkNotification)
             }
             .store(in: &subscriptions)
     }

--- a/Koin/Presentation/NewHome/HomeTabbar/HomeTabbarController.swift
+++ b/Koin/Presentation/NewHome/HomeTabbar/HomeTabbarController.swift
@@ -199,8 +199,6 @@ extension HomeTabBarController {
             "알림 아이콘"
         ))
         navigateToNotification()
-        
-        print(KeychainWorker.shared.read(key: .fcm))
     }
     
     private func navigateToNotification() {

--- a/Koin/Presentation/NewHome/HomeTabbar/HomeTabbarController.swift
+++ b/Koin/Presentation/NewHome/HomeTabbar/HomeTabbarController.swift
@@ -74,14 +74,22 @@ final class HomeTabBarController: UITabBarController {
 
 extension HomeTabBarController {
     private func setUpViewControllers() {
-        let configuredViewControllers = items.map { configuration in
+        let viewControllers = setUpTabBar(items: items)
+        configureNavigationBar(viewControllers: viewControllers)
+        self.viewControllers = viewControllers.map { CustomNavigationController(rootViewController: $0) }
+    }
+    
+    private func setUpTabBar(items: [HomeTabBarItem]) -> [UIViewController] {
+        items.map { configuration in
             let tabBar = HomeTabBar(
                 tabs: items.map(\.tab),
                 selectedTab: configuration.tab
             ) { [weak self] tag in
                 self?.handleTabSelection(tag: tag)
             }
+            
             tabBars.append(tabBar)
+            
             let rootViewController = configuration.viewController.then {
                 $0.view?.addSubview(tabBar)
                 tabBar.snp.makeConstraints {
@@ -89,9 +97,81 @@ extension HomeTabBarController {
                     $0.height.equalTo(Layout.TabBarBaseHeight + TabBarBottomPadding)
                 }
             }
-            return CustomNavigationController(rootViewController: rootViewController)
+            
+            return rootViewController
         }
-        viewControllers = configuredViewControllers
+    }
+    
+    private func configureNavigationBar(viewControllers: [UIViewController]) {
+        var viewControllers = viewControllers
+        
+        for index in items.indices {
+            var navigationBarStyle: NavigationBarStyle
+            switch items[index].tab {
+            case .home, .category, .profile:
+                navigationBarStyle = .order
+            case .board:
+                navigationBarStyle = .empty
+            }
+            
+            viewControllers[index].configureNavigationBar(style: navigationBarStyle)
+        }
+        
+        viewControllers.forEach { viewController in
+            configureLeftBarItem(viewController: viewController)
+        }
+    }
+    
+    private func configureLeftBarItem(viewController: UIViewController) {
+        let viewController = viewController
+        let leftBarButtonItem = UIBarButtonItem(customView: HomeLogoView())
+        viewController.navigationItem.leftBarButtonItem = leftBarButtonItem
+    }
+}
+
+extension HomeTabBarController {
+    
+    private func configureRightBarButton(hasUnreadNotifications hasDot: Bool = false) {
+        viewControllers?.forEach { navigationController in
+            guard let rootViewController = (navigationController as? UINavigationController)?.viewControllers.first else {
+                return
+            }
+            let rightBarButtonItem = UIBarButtonItem(
+                image: .appImage(asset: hasDot ? .homeBellDot : .homeBell)?.withRenderingMode(.alwaysOriginal),
+                style: .plain,
+                target: self,
+                action: #selector(rightBarButtonTapped)
+            )
+            rootViewController.navigationItem.rightBarButtonItem = rightBarButtonItem
+        }
+    }
+    
+    @objc private func rightBarButtonTapped() {
+        inputSubject.send(.logEvent(
+            EventParameter.EventLabel.Campus.notification,
+            .click,
+            "알림 아이콘"
+        ))
+        navigateToNotification()
+        
+        print(KeychainWorker.shared.read(key: .fcm))
+    }
+    
+    private func navigateToNotification() {
+        let notificatioHistoryRepository = DefaultNotificationHistoryRepository(service: DefaultNotificationHistoryService())
+        let fetchNotificationHistoryUseCase = DefaultFetchNotificationHistoryUseCase(notificationHistoryRepository: notificatioHistoryRepository)
+        let deleteNotificationHistoryUseCase = DefaultDeleteNotificationHistoryUseCase(repository: notificatioHistoryRepository)
+        let updateNotificationHistoryUseCase = DefaultUpdateNotificationHistoryUseCase(repository: notificatioHistoryRepository)
+        
+        let logAnalyticsEventUseCase = DefaultLogAnalyticsEventUseCase(repository: GA4AnalyticsRepository(service: GA4AnalyticsService()))
+        let viewModel = NotificationViewModel(
+            fetchNotificationHistoryUseCase: fetchNotificationHistoryUseCase,
+            deleteNotificationHistoryUseCase: deleteNotificationHistoryUseCase,
+            updateNotificationHistoryUseCase: updateNotificationHistoryUseCase,
+            logAnalyticsEventUseCase: logAnalyticsEventUseCase
+        )
+        let viewController = NotificationViewController(viewModel: viewModel)
+        (selectedViewController as? UINavigationController)?.pushViewController(viewController, animated: true)
     }
 }
 

--- a/Koin/Presentation/NewHome/HomeTabbar/HomeTabbarController.swift
+++ b/Koin/Presentation/NewHome/HomeTabbar/HomeTabbarController.swift
@@ -59,6 +59,11 @@ final class HomeTabBarController: UITabBarController {
         }
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        inputSubject.send(.checkNotification)
+    }
+    
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         updateAdditionalBottomInset()
@@ -69,6 +74,19 @@ final class HomeTabBarController: UITabBarController {
         super.viewSafeAreaInsetsDidChange()
         updateAdditionalBottomInset()
         updateTabBarLayout()
+    }
+    
+    // MARK: - Bind
+    private func bind() {
+        viewModel.transform(with: inputSubject.eraseToAnyPublisher())
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] output in
+                switch output {
+                case .hasUnreadNotifications(let hasUnreadNotifications):
+                    self?.configureRightBarButton(hasUnreadNotifications: hasUnreadNotifications)
+                }
+            }
+            .store(in: &subscriptions)
     }
 }
 
@@ -193,11 +211,6 @@ extension HomeTabBarController {
 }
 
 extension HomeTabBarController {
-    private func bind() {
-        viewModel.transform(with: inputSubject.eraseToAnyPublisher())
-            .sink { _ in }
-            .store(in: &subscriptions)
-    }
 
     private func handleTabSelection(tag: Int) {
         guard let index = items.firstIndex(where: { $0.tab.rawValue == tag }) else {

--- a/Koin/Presentation/NewHome/HomeTabbar/HomeTabbarViewModel.swift
+++ b/Koin/Presentation/NewHome/HomeTabbar/HomeTabbarViewModel.swift
@@ -10,18 +10,26 @@ import Combine
 final class HomeTabBarViewModel: ViewModelProtocol {
     enum Input {
         case logEvent(EventLabelType, EventParameter.EventCategory, Any)
+        case checkNotification
     }
     
-    enum Output {}
+    enum Output {
+        case hasUnreadNotifications(Bool)
+    }
 
     // MARK: - Properties
     private let logAnalyticsEventUseCase: LogAnalyticsEventUseCase
+    private let fetchNotificationHistoryUseCase: FetchNotificationHistoryUseCase
     private let outputSubject = PassthroughSubject<Output, Never>()
     private var subscriptions: Set<AnyCancellable> = []
 
     // MARK: - Initializer
-    init(logAnalyticsEventUseCase: LogAnalyticsEventUseCase) {
+    init(
+        logAnalyticsEventUseCase: LogAnalyticsEventUseCase,
+        fetchNotificationHistoryUseCase: FetchNotificationHistoryUseCase
+    ) {
         self.logAnalyticsEventUseCase = logAnalyticsEventUseCase
+        self.fetchNotificationHistoryUseCase = fetchNotificationHistoryUseCase
     }
 
     // MARK: - Transform
@@ -30,6 +38,8 @@ final class HomeTabBarViewModel: ViewModelProtocol {
             switch input {
             case let .logEvent(label, category, value):
                 self?.makeLogAnalyticsEvent(label: label, category: category, value: value)
+            case .checkNotification:
+                self?.checkNotification()
             }
         }.store(in: &subscriptions)
         
@@ -45,5 +55,13 @@ extension HomeTabBarViewModel {
         value: Any
     ) {
         logAnalyticsEventUseCase.execute(label: label, category: category, value: value)
+    }
+    
+    private func checkNotification() {
+        Task {
+            let notifications = try? await fetchNotificationHistoryUseCase.execute()
+            let unreadNotifications = notifications?.filter { !$0.isRead }
+            outputSubject.send(.hasUnreadNotifications(unreadNotifications?.isEmpty == false))
+        }
     }
 }

--- a/Koin/Presentation/NewHome/HomeTabbar/HomeTabbarViewModel.swift
+++ b/Koin/Presentation/NewHome/HomeTabbar/HomeTabbarViewModel.swift
@@ -19,17 +19,17 @@ final class HomeTabBarViewModel: ViewModelProtocol {
 
     // MARK: - Properties
     private let logAnalyticsEventUseCase: LogAnalyticsEventUseCase
-    private let fetchNotificationHistoryUseCase: FetchNotificationHistoryUseCase
+    private let checkHasUnreadNotificationHistoryUseCase: CheckHasUnreadNotificationHistoryUseCase
     private let outputSubject = PassthroughSubject<Output, Never>()
     private var subscriptions: Set<AnyCancellable> = []
 
     // MARK: - Initializer
     init(
         logAnalyticsEventUseCase: LogAnalyticsEventUseCase,
-        fetchNotificationHistoryUseCase: FetchNotificationHistoryUseCase
+        checkHasUnreadNotificationHistoryUseCase: CheckHasUnreadNotificationHistoryUseCase
     ) {
         self.logAnalyticsEventUseCase = logAnalyticsEventUseCase
-        self.fetchNotificationHistoryUseCase = fetchNotificationHistoryUseCase
+        self.checkHasUnreadNotificationHistoryUseCase = checkHasUnreadNotificationHistoryUseCase
     }
 
     // MARK: - Transform
@@ -39,7 +39,7 @@ final class HomeTabBarViewModel: ViewModelProtocol {
             case let .logEvent(label, category, value):
                 self?.makeLogAnalyticsEvent(label: label, category: category, value: value)
             case .checkNotification:
-                self?.checkNotification()
+                self?.checkUnreadNotifications()
             }
         }.store(in: &subscriptions)
         
@@ -57,11 +57,15 @@ extension HomeTabBarViewModel {
         logAnalyticsEventUseCase.execute(label: label, category: category, value: value)
     }
     
-    private func checkNotification() {
+    private func checkUnreadNotifications() {
         Task {
-            let notifications = try? await fetchNotificationHistoryUseCase.execute()
-            let unreadNotifications = notifications?.filter { !$0.isRead }
-            outputSubject.send(.hasUnreadNotifications(unreadNotifications?.isEmpty == false))
+            do {
+                let hasUnreadNotifications = try await checkHasUnreadNotificationHistoryUseCase.execute()
+                outputSubject.send(.hasUnreadNotifications(hasUnreadNotifications))
+            } catch {
+                print(#function, "failed")
+                print(error)
+            }
         }
     }
 }

--- a/Koin/Presentation/NewHome/Profile/ProfileHostingController.swift
+++ b/Koin/Presentation/NewHome/Profile/ProfileHostingController.swift
@@ -19,12 +19,6 @@ final class ProfileHostingController: UIHostingController<ProfileView>, HostingC
         fatalError("init(coder:) has not been implemented")
     }
     
-    // MARK: - Life Cycle
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        configureNavigationBar()
-    }
-    
     // MARK: - Public
     func execute(action: ProfileView.Action) {
         switch action {
@@ -37,53 +31,6 @@ final class ProfileHostingController: UIHostingController<ProfileView>, HostingC
         case .showTimeTable:
             navigationController?.pushViewController(makeTimeTableViewController(), animated: true)
         }
-    }
-}
-
-extension ProfileHostingController {
-    private func configureNavigationBar() {
-        configureNavigationBar(style: .order)
-        configureLeftBarItem()
-        configureRightBarButton()
-    }
-
-    private func configureLeftBarItem() {
-        let leftBarButtonItem = UIBarButtonItem(customView: HomeLogoView())
-        navigationItem.leftBarButtonItem = leftBarButtonItem
-    }
-
-    private func configureRightBarButton(hasDot: Bool = false) {
-        navigationItem.rightBarButtonItem = UIBarButtonItem(
-            image: .appImage(asset: hasDot ? .homeBellDot : .homeBell)?.withRenderingMode(.alwaysOriginal),
-            style: .plain,
-            target: self,
-            action: #selector(rightBarButtonTapped)
-        )
-    }
-
-    @objc private func rightBarButtonTapped() {
-        rootView.makeLogAnalyticsEvent(
-            label: EventParameter.EventLabel.Campus.notification,
-            category: .click,
-            value: "알림 아이콘")
-        navigateToNotification()
-    }
-     
-    private func navigateToNotification() {
-        let notificatioHistoryRepository = DefaultNotificationHistoryRepository(service: DefaultNotificationHistoryService())
-        let fetchNotificationHistoryUseCase = DefaultFetchNotificationHistoryUseCase(notificationHistoryRepository: notificatioHistoryRepository)
-        let deleteNotificationHistoryUseCase = DefaultDeleteNotificationHistoryUseCase(repository: notificatioHistoryRepository)
-        let updateNotificationHistoryUseCase = DefaultUpdateNotificationHistoryUseCase(repository: notificatioHistoryRepository)
-        
-        let logAnalyticsEventUseCase = DefaultLogAnalyticsEventUseCase(repository: GA4AnalyticsRepository(service: GA4AnalyticsService()))
-        let viewModel = NotificationViewModel(
-            fetchNotificationHistoryUseCase: fetchNotificationHistoryUseCase,
-            deleteNotificationHistoryUseCase: deleteNotificationHistoryUseCase,
-            updateNotificationHistoryUseCase: updateNotificationHistoryUseCase,
-            logAnalyticsEventUseCase: logAnalyticsEventUseCase
-        )
-        let viewController = NotificationViewController(viewModel: viewModel)
-        navigationController?.pushViewController(viewController, animated: true)
     }
 }
 

--- a/Koin/Presentation/Notice/NoticeList/NoticeListViewController.swift
+++ b/Koin/Presentation/Notice/NoticeList/NoticeListViewController.swift
@@ -91,7 +91,6 @@ final class NoticeListViewController: UIViewController, UIGestureRecognizerDeleg
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        configureNavigationBar()
         if !hasAppeared {
             inputSubject.send(.getUserKeywordList())
             hasAppeared = true
@@ -197,50 +196,6 @@ final class NoticeListViewController: UIViewController, UIGestureRecognizerDeleg
             }
             inputSubject.send(.logEvent(EventParameter.EventLabel.Campus.itemPostType, .click, text))
         }.store(in: &subscriptions)
-    }
-}
-
-extension NoticeListViewController {
-    private func configureNavigationBar() {
-        configureNavigationBar(style: .empty)
-        configureLeftBarItem()
-        configureRightBarButton()
-    }
-
-    private func configureLeftBarItem() {
-        let leftBarButtonItem = UIBarButtonItem(customView: HomeLogoView())
-        navigationItem.leftBarButtonItem = leftBarButtonItem
-    }
-
-    private func configureRightBarButton(hasDot: Bool = false) {
-        navigationItem.rightBarButtonItem = UIBarButtonItem(
-            image: .appImage(asset: hasDot ? .homeBellDot : .homeBell)?.withRenderingMode(.alwaysOriginal),
-            style: .plain,
-            target: self,
-            action: #selector(rightBarButtonTapped)
-        )
-    }
-
-    @objc private func rightBarButtonTapped() {
-        inputSubject.send(.logEvent(EventParameter.EventLabel.Campus.notification, .click, "알림 아이콘"))
-        navigateToNotification()
-    }
-     
-    private func navigateToNotification() {
-        let notificatioHistoryRepository = DefaultNotificationHistoryRepository(service: DefaultNotificationHistoryService())
-        let fetchNotificationHistoryUseCase = DefaultFetchNotificationHistoryUseCase(notificationHistoryRepository: notificatioHistoryRepository)
-        let deleteNotificationHistoryUseCase = DefaultDeleteNotificationHistoryUseCase(repository: notificatioHistoryRepository)
-        let updateNotificationHistoryUseCase = DefaultUpdateNotificationHistoryUseCase(repository: notificatioHistoryRepository)
-        
-        let logAnalyticsEventUseCase = DefaultLogAnalyticsEventUseCase(repository: GA4AnalyticsRepository(service: GA4AnalyticsService()))
-        let viewModel = NotificationViewModel(
-            fetchNotificationHistoryUseCase: fetchNotificationHistoryUseCase,
-            deleteNotificationHistoryUseCase: deleteNotificationHistoryUseCase,
-            updateNotificationHistoryUseCase: updateNotificationHistoryUseCase,
-            logAnalyticsEventUseCase: logAnalyticsEventUseCase
-        )
-        let viewController = NotificationViewController(viewModel: viewModel)
-        navigationController?.pushViewController(viewController, animated: true)
     }
 }
 

--- a/Koin/Presentation/TimeTable/Timetable/TimetableViewController.swift
+++ b/Koin/Presentation/TimeTable/Timetable/TimetableViewController.swift
@@ -127,7 +127,6 @@ final class TimetableViewController: UIViewController {
         bind()
         configureView()
         inputSubject.send(.fetchMySemester)
-        print(KeychainWorker.shared.read(key: .access))
         semesterSelectButton.addTarget(self, action: #selector(modifySemesterButtonTapped), for: .touchUpInside)
         downloadImageButton.addTarget(self, action: #selector(downloadTimetableAsImage), for: .touchUpInside)
     }

--- a/koin.xcodeproj/project.pbxproj
+++ b/koin.xcodeproj/project.pbxproj
@@ -204,6 +204,7 @@
 		7C7F56BC2FFBA18100847151 /* NotificationHistoryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C7F56BA2FFBA18100847151 /* NotificationHistoryService.swift */; };
 		7C82FF782E9D18C7006335A7 /* OrderShopDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C82FF772E9D18C7006335A7 /* OrderShopDetail.swift */; };
 		7C85D2752EBDE374005E63FF /* FetchOrderShopMenusAndGroupsFromShopUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C85D2742EBDE374005E63FF /* FetchOrderShopMenusAndGroupsFromShopUseCase.swift */; };
+		7C86750E30061AA0003CB942 /* CheckUnreadNotificationHistoryUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C86750D30061AA0003CB942 /* CheckUnreadNotificationHistoryUseCase.swift */; };
 		7C8A00012FD000000011D338 /* NewHomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C8A00022FD000000011D338 /* NewHomeViewModel.swift */; };
 		7C8A00072FD200000011D338 /* DiningHeaderButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C8A00082FD200000011D338 /* DiningHeaderButton.swift */; };
 		7C8A00092FD200000011D338 /* DiningCarousel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C8A000A2FD200000011D338 /* DiningCarousel.swift */; };
@@ -1231,6 +1232,7 @@
 		7C7F56BA2FFBA18100847151 /* NotificationHistoryService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationHistoryService.swift; sourceTree = "<group>"; };
 		7C82FF772E9D18C7006335A7 /* OrderShopDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderShopDetail.swift; sourceTree = "<group>"; };
 		7C85D2742EBDE374005E63FF /* FetchOrderShopMenusAndGroupsFromShopUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchOrderShopMenusAndGroupsFromShopUseCase.swift; sourceTree = "<group>"; };
+		7C86750D30061AA0003CB942 /* CheckUnreadNotificationHistoryUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckUnreadNotificationHistoryUseCase.swift; sourceTree = "<group>"; };
 		7C8A00022FD000000011D338 /* NewHomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewHomeViewModel.swift; sourceTree = "<group>"; };
 		7C8A00082FD200000011D338 /* DiningHeaderButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiningHeaderButton.swift; sourceTree = "<group>"; };
 		7C8A000A2FD200000011D338 /* DiningCarousel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiningCarousel.swift; sourceTree = "<group>"; };
@@ -2662,6 +2664,7 @@
 				7C8BFCE92FD04BA000963679 /* FetchNotificationListUseCase.swift */,
 				7CA6868A2FFCE750007937E9 /* DeleteNotificationHistoryUseCase.swift */,
 				7CA6868C2FFCE867007937E9 /* UpdateNotificationHistoryUseCase.swift */,
+				7C86750D30061AA0003CB942 /* CheckUnreadNotificationHistoryUseCase.swift */,
 			);
 			path = NewHome;
 			sourceTree = "<group>";
@@ -5982,6 +5985,7 @@
 				7CED90E62EF2D1F900457128 /* DeleteReviewModalViewController.swift in Sources */,
 				7CED90E72EF2D1F900457128 /* ForceUpdateViewController.swift in Sources */,
 				7CED90E92EF2D1F900457128 /* DiningCollectionView.swift in Sources */,
+				7C86750E30061AA0003CB942 /* CheckUnreadNotificationHistoryUseCase.swift in Sources */,
 				7CED90EB2EF2D1F900457128 /* LandViewController.swift in Sources */,
 				7CED90ED2EF2D1F900457128 /* HomeViewModel.swift in Sources */,
 				7CED90EF2EF2D1F900457128 /* ShopReviewReportViewModel.swift in Sources */,

--- a/koin.xcodeproj/project.pbxproj
+++ b/koin.xcodeproj/project.pbxproj
@@ -204,7 +204,7 @@
 		7C7F56BC2FFBA18100847151 /* NotificationHistoryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C7F56BA2FFBA18100847151 /* NotificationHistoryService.swift */; };
 		7C82FF782E9D18C7006335A7 /* OrderShopDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C82FF772E9D18C7006335A7 /* OrderShopDetail.swift */; };
 		7C85D2752EBDE374005E63FF /* FetchOrderShopMenusAndGroupsFromShopUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C85D2742EBDE374005E63FF /* FetchOrderShopMenusAndGroupsFromShopUseCase.swift */; };
-		7C86750E30061AA0003CB942 /* CheckUnreadNotificationHistoryUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C86750D30061AA0003CB942 /* CheckUnreadNotificationHistoryUseCase.swift */; };
+		7C86750E30061AA0003CB942 /* CheckHasUnreadNotificationHistoryUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C86750D30061AA0003CB942 /* CheckHasUnreadNotificationHistoryUseCase.swift */; };
 		7C8A00012FD000000011D338 /* NewHomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C8A00022FD000000011D338 /* NewHomeViewModel.swift */; };
 		7C8A00072FD200000011D338 /* DiningHeaderButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C8A00082FD200000011D338 /* DiningHeaderButton.swift */; };
 		7C8A00092FD200000011D338 /* DiningCarousel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C8A000A2FD200000011D338 /* DiningCarousel.swift */; };
@@ -1232,7 +1232,7 @@
 		7C7F56BA2FFBA18100847151 /* NotificationHistoryService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationHistoryService.swift; sourceTree = "<group>"; };
 		7C82FF772E9D18C7006335A7 /* OrderShopDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderShopDetail.swift; sourceTree = "<group>"; };
 		7C85D2742EBDE374005E63FF /* FetchOrderShopMenusAndGroupsFromShopUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchOrderShopMenusAndGroupsFromShopUseCase.swift; sourceTree = "<group>"; };
-		7C86750D30061AA0003CB942 /* CheckUnreadNotificationHistoryUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckUnreadNotificationHistoryUseCase.swift; sourceTree = "<group>"; };
+		7C86750D30061AA0003CB942 /* CheckHasUnreadNotificationHistoryUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckHasUnreadNotificationHistoryUseCase.swift; sourceTree = "<group>"; };
 		7C8A00022FD000000011D338 /* NewHomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewHomeViewModel.swift; sourceTree = "<group>"; };
 		7C8A00082FD200000011D338 /* DiningHeaderButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiningHeaderButton.swift; sourceTree = "<group>"; };
 		7C8A000A2FD200000011D338 /* DiningCarousel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiningCarousel.swift; sourceTree = "<group>"; };
@@ -2664,7 +2664,7 @@
 				7C8BFCE92FD04BA000963679 /* FetchNotificationListUseCase.swift */,
 				7CA6868A2FFCE750007937E9 /* DeleteNotificationHistoryUseCase.swift */,
 				7CA6868C2FFCE867007937E9 /* UpdateNotificationHistoryUseCase.swift */,
-				7C86750D30061AA0003CB942 /* CheckUnreadNotificationHistoryUseCase.swift */,
+				7C86750D30061AA0003CB942 /* CheckHasUnreadNotificationHistoryUseCase.swift */,
 			);
 			path = NewHome;
 			sourceTree = "<group>";
@@ -5985,7 +5985,7 @@
 				7CED90E62EF2D1F900457128 /* DeleteReviewModalViewController.swift in Sources */,
 				7CED90E72EF2D1F900457128 /* ForceUpdateViewController.swift in Sources */,
 				7CED90E92EF2D1F900457128 /* DiningCollectionView.swift in Sources */,
-				7C86750E30061AA0003CB942 /* CheckUnreadNotificationHistoryUseCase.swift in Sources */,
+				7C86750E30061AA0003CB942 /* CheckHasUnreadNotificationHistoryUseCase.swift in Sources */,
 				7CED90EB2EF2D1F900457128 /* LandViewController.swift in Sources */,
 				7CED90ED2EF2D1F900457128 /* HomeViewModel.swift in Sources */,
 				7CED90EF2EF2D1F900457128 /* ShopReviewReportViewModel.swift in Sources */,


### PR DESCRIPTION
## #️⃣연관된 이슈

- #484

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

1. 네개의 ViewController에 중복되어있는 네비게이션바 설정 로직을 HomeTabBarController로 모았습니다.
2. 읽지 않은 알림의 존재 여부에 따라 알림화면 진입 버튼의 상태를 변화하는 기능을 구현했습니다. 상태를 확인하는 때는 다음과 같습니다.
   - 앱 첫 실행시
   - 앱 이탈 후 복귀시
   - 알림 읽음/삭제 처리시
   - 새로운 알림 도착시


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added unread notification detection for the home screen.
  * Added an unread indicator to the notification button.
  * Notification status now refreshes when notifications are received, read, or the app becomes active.
  * Home, category, and profile tabs now load with complete navigation experiences.

* **Bug Fixes**
  * Notification state now updates consistently after notification changes and deletions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->