### PR TITLE
feat, fix: 푸시알림 관련 수정

### DIFF
--- a/Common/Core/AppPath.swift
+++ b/Common/Core/AppPath.swift
@@ -8,14 +8,10 @@
 import Foundation
 
 enum AppPath: String, Codable {
-    case home
-    case login
     case shop
     case dining
     case keyword
     case chat
     case callvan
     case callvanChat = "callvan-chat"
-    case club
-    case timeTable = "timetable"
 }

--- a/Koin/Apps/AppDelegate.swift
+++ b/Koin/Apps/AppDelegate.swift
@@ -15,18 +15,16 @@ import SwiftRater
 class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterDelegate {
     
     var window: UIWindow?
-    var sceneDelegate: SceneDelegate? {
-        let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
-        return windowScene?.delegate as? SceneDelegate
-    }
-
-    // MARK: - 푸시알림을 탭했을 때의 동작 구현
+    
+    // MARK: - 푸시알림 Warm Start & Cold Start (optional)
     func userNotificationCenter(
         _ center: UNUserNotificationCenter,
         didReceive response: UNNotificationResponse,
         withCompletionHandler completionHandler: @escaping () -> Void
     ) {
+        let sceneDelegate = response.targetScene?.delegate as? SceneDelegate
         let userInfo = response.notification.request.content.userInfo
+        
         sceneDelegate?.handleNotificationData(userInfo: userInfo)
         completionHandler()
     }
@@ -57,7 +55,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         return true
     }
     
-    // MARK: - APNS 토큰 처리
+    // MARK: - APNs 토큰 처리
     func application(
         _ application: UIApplication,
         didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data

--- a/Koin/Apps/SceneDelegate.swift
+++ b/Koin/Apps/SceneDelegate.swift
@@ -12,6 +12,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     // MARK: - Properties
     var window: UIWindow?
     private var isPresentingErrorViewController = false
+    private var handledMessageIds: [String] = []
     
     var navigationController: UINavigationController? {
         (window?.rootViewController as? HomeTabBarController)?.selectedViewController as? UINavigationController
@@ -32,7 +33,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         NotificationCenter.default.removeObserver(self)
     }
     
-    // MARK: - cold start & 딥링크
+    // MARK: - cold start
     func scene(
         _ scene: UIScene,
         willConnectTo session: UISceneSession,
@@ -52,6 +53,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             handleIncomingDeepLink(url: incomingURL)
         } else if let urlContext = connectionOptions.urlContexts.first {
             handleIncomingDeepLink(url: urlContext.url)
+        }
+        
+        // MARK: - 푸시알림 Cold Start
+        if let userInfo = connectionOptions.notificationResponse?.notification.request.content.userInfo {
+            handleNotificationData(userInfo: userInfo)
         }
     }
     
@@ -103,7 +109,15 @@ extension SceneDelegate {
     
     // MARK: - 푸시알림 처리
     func handleNotificationData(userInfo: [AnyHashable: Any]) {
-        guard let aps = userInfo["aps"] as? [String: AnyObject], let category = aps["category"] as? String,
+        // Cold Start 푸시알림 중복처리 방지
+        guard let messageId = userInfo["gcm.message_id"] as? String,
+              !handledMessageIds.contains(messageId) else {
+            return
+        }
+        handledMessageIds.append(messageId)
+        
+        guard let aps = userInfo["aps"] as? [String: AnyObject],
+              let category = aps["category"] as? String,
               let category = AppPath(rawValue: category) else {
             print("Invalid notification data")
             return

--- a/Koin/Apps/SceneDelegate.swift
+++ b/Koin/Apps/SceneDelegate.swift
@@ -118,63 +118,53 @@ extension SceneDelegate {
         
         guard let aps = userInfo["aps"] as? [String: AnyObject],
               let category = aps["category"] as? String,
-              let category = AppPath(rawValue: category) else {
+              let appPath = AppPath(rawValue: category),
+              let schemeUri = userInfo["schemeUri"] as? String,
+              let parsedQuery = parseQuery(uri: schemeUri) else {
             print("Invalid notification data")
             return
         }
-        let schemeUri = userInfo["schemeUri"] as? String
         
-        switch category {
+        switch appPath {
         case .shop:
-            let shopViewController = makeShopViewController()
-            navigationController?.pushViewController(shopViewController, animated: true)
+            if let shopId = Int(parsedQuery["id"]) {
+                let shopSummaryViewController = makeShopSummaryViewController(shopId: shopId)
+                navigationController?.pushViewController(shopSummaryViewController, animated: true)
+            }
         case .dining:
             let diningViewController = makeDiningViewController()
             navigationController?.pushViewController(diningViewController, animated: true)
-        case .keyword:
-            guard let id = extractValue(from: schemeUri, value: "id"), let intId = Int(id) else {
-                print("noticeId : Invalid or missing")
-                return
-            }
-            
-            let noticeDataViewController = makeNoticeDataViewController(noticeId: intId)
-            navigationController?.pushViewController(noticeDataViewController, animated: true)
-            
-            if let keyword = extractValue(from: schemeUri, value: "keyword") {
-                DefaultLogAnalyticsEventUseCase(
-                    repository: GA4AnalyticsRepository(service: GA4AnalyticsService())
-                ).execute(
-                    label: EventParameter.EventLabel.Campus.keywordNotification,
-                    category: .notification,
-                    value: keyword
-                )
-            }
         case .chat:
-            guard let articleId = extractValue(from: schemeUri, value: "articleId"), let intArticleId = Int(articleId) else {
-                print("articleId : Invalid or missing")
-                return
+            if let articleId = Int(parsedQuery["articleId"]),
+               let chatRoomId = Int(parsedQuery["chatRoomId"]) {
+                let viewModel = ChatViewModel(articleId: articleId, chatRoomId: chatRoomId, articleTitle: nil)
+                let chatViewController = ChatViewController(viewModel: viewModel)
+                navigationController?.pushViewController(chatViewController, animated: true)
             }
-            guard let chatRoomId = extractValue(from: schemeUri, value: "chatRoomId"), let intChatRoomId = Int(chatRoomId) else {
-                print("chatRoomId : Invalid or missing")
-                return
-            }
-            let viewModel = ChatViewModel(articleId: intArticleId, chatRoomId: intChatRoomId, articleTitle: nil)
-            let chatViewController = ChatViewController(viewModel: viewModel)
-            navigationController?.pushViewController(chatViewController, animated: true)
         case .callvan:
-            guard let postId = extractValue(from: schemeUri, value: "id"), let intPostId = Int(postId) else {
-                print("postId : Invalid or missing")
-                return
+            if let postId = Int(parsedQuery["id"]) {
+                let callVanDataViewController = makeCallVanDataViewController(postId: postId)
+                navigationController?.pushViewController(callVanDataViewController, animated: true)
             }
-            let callVanDataViewController = makeCallVanDataViewController(postId: intPostId)
-            navigationController?.pushViewController(callVanDataViewController, animated: true)
         case .callvanChat:
-            guard let postId = extractValue(from: schemeUri, value: "postId"), let intPostId = Int(postId) else {
-                print("postId : Invalid or missing")
+            if let postId = Int(parsedQuery["postId"]),
+               let chatRoomId = Int(parsedQuery["chatRoomId"]) {
+                let callVanChatViewController = makeCallVanChatViewController(postId: postId)
+                navigationController?.pushViewController(callVanChatViewController, animated: true)
+                
+            }
+        case .keyword:
+            guard let noticeId = Int(parsedQuery["id"]),
+                  let boardId = Int(parsedQuery["board-id"]) else {
                 return
             }
-            let callVanChatViewController = makeCallVanChatViewController(postId: intPostId)
-            navigationController?.pushViewController(callVanChatViewController, animated: true)
+            let viewController: UIViewController
+            if boardId == 14 {
+                viewController = makeLostItemData(lostItemId: noticeId)
+            } else {
+                viewController = makeNoticeDataViewController(noticeId: noticeId, boardId: boardId)
+            }
+            navigationController?.pushViewController(viewController, animated: true)
         }
     }
 }
@@ -380,7 +370,30 @@ extension SceneDelegate {
         return callVanChatViewController
     }
 
-    private func makeNoticeDataViewController(noticeId: Int) -> NoticeDataViewController {
+    private func makeLostItemData(lostItemId: Int) -> UIViewController {
+        let userRepository = DefaultUserRepository(service: DefaultUserService())
+        let lostItemRepository = DefaultLostItemRepository(service: DefaultLostItemService())
+        let chatRepository = DefaultChatRepository(service: DefaultChatService())
+        let checkLoginUseCase = DefaultCheckLoginUseCase(userRepository: userRepository)
+        let fetchLostItemDataUseCase = DefaultFetchLostItemDataUseCase(repository: lostItemRepository)
+        let fetchLostItemListUseCase = DefaultFetchLostItemListUseCase(repository: lostItemRepository)
+        let changeLostItemStateUseCase = DefaultChangeLostItemStateUseCase(repository: lostItemRepository)
+        let deleteLostItemUseCase = DefaultDeleteLostItemUseCase(repository: lostItemRepository)
+        let createChatRoomUseCase = DefaultCreateChatRoomUseCase(chatRepository: chatRepository)
+        let logAnalyticsEventUseCase = DefaultLogAnalyticsEventUseCase(repository: GA4AnalyticsRepository(service: GA4AnalyticsService()))
+        let viewModel = LostItemDataViewModel(
+            checkLoginUseCase: checkLoginUseCase,
+            fetchLostItemDataUseCase: fetchLostItemDataUseCase,
+            fetchLostItemListUseCase: fetchLostItemListUseCase,
+            changeLostItemStateUseCase: changeLostItemStateUseCase,
+            deleteLostItemUseCase: deleteLostItemUseCase,
+            createChatRoomUseCase: createChatRoomUseCase,
+            logAnalyticsEventUseCase: logAnalyticsEventUseCase,
+            id: lostItemId)
+        return LostItemDataViewController(viewModel: viewModel)
+    }
+    
+    private func makeNoticeDataViewController(noticeId: Int, boardId: Int) -> NoticeDataViewController {
         let service = DefaultNoticeService()
         let repository = DefaultNoticeListRepository(service: service)
         let viewModel = NoticeDataViewModel(
@@ -388,10 +401,10 @@ extension SceneDelegate {
             fetchHotNoticeArticlesUseCase: DefaultFetchHotNoticeArticlesUseCase(noticeListRepository: repository),
             downloadNoticeAttachmentUseCase: DefaultDownloadNoticeAttachmentsUseCase(noticeRepository: repository),
             logAnalyticsEventUseCase: DefaultLogAnalyticsEventUseCase(repository: GA4AnalyticsRepository(service: GA4AnalyticsService())),
-            noticeId: noticeId, boardId: -1
+            noticeId: noticeId,
+            boardId: boardId
         )
-        let viewController = NoticeDataViewController(viewModel: viewModel)
-        return viewController
+        return NoticeDataViewController(viewModel: viewModel)
     }
     
     private func makeDiningViewController() -> DiningViewController {
@@ -413,27 +426,25 @@ extension SceneDelegate {
         return diningViewController
     }
     
-    private func makeShopViewController() -> ShopViewController {
-        let shopService = DefaultShopService()
-        let shopRepository = DefaultShopRepository(service: shopService)
-        let fetchShopListUseCase = DefaultFetchShopListUseCase(shopRepository: shopRepository)
-        let fetchEventListUseCase = DefaultFetchEventListUseCase(shopRepository: shopRepository)
-        let fetchShopCategoryListUseCase = DefaultFetchShopCategoryListUseCase(shopRepository: shopRepository)
-        let fetchShopBenefitUseCase = DefaultFetchShopBenefitUseCase(shopRepository: shopRepository)
-        let fetchBeneficialShopUseCase = DefaultFetchBeneficialShopUseCase(shopRepository: shopRepository)
+    private func makeShopSummaryViewController(shopId: Int) -> UIViewController {
+        let repository = DefaultShopRepository(service: DefaultShopService())
+        let fetchOrderShopSummaryFromShopUseCase = DefaultFetchOrderShopSummaryFromShopUseCase(repository: repository)
+        let fetchOrderShopMenusAndGroupsFromShopUseCase = DefaultFetchOrderShopMenusAndGroupsFromShopUseCase(shopRepository: repository)
+        let fetchShopDataUseCase = DefaultFetchShopDataUseCase(shopRepository: repository)
+        let fetchShopEventListUseCase = DefaultFetchShopEventListUseCase(shopRepository: repository)
         let logAnalyticsEventUseCase = DefaultLogAnalyticsEventUseCase(repository: GA4AnalyticsRepository(service: GA4AnalyticsService()))
         let getUserScreenTimeUseCase = DefaultGetUserScreenTimeUseCase()
-        let viewModel = ShopViewModel(
-            fetchShopListUseCase: fetchShopListUseCase,
-            fetchEventListUseCase: fetchEventListUseCase,
-            fetchShopCategoryListUseCase: fetchShopCategoryListUseCase,
-            fetchShopBenefitUseCase: fetchShopBenefitUseCase,
-            fetchBeneficialShopUseCase: fetchBeneficialShopUseCase,
+        let viewModel = ShopSummaryViewModel(
+            fetchOrderShopSummaryFromShopUseCase: fetchOrderShopSummaryFromShopUseCase,
+            fetchOrderShopMenusAndGroupsFromShopUseCase: fetchOrderShopMenusAndGroupsFromShopUseCase,
+            fetchShopDataUseCase: fetchShopDataUseCase,
+            fetchShopEventListUseCase: fetchShopEventListUseCase,
             logAnalyticsEventUseCase: logAnalyticsEventUseCase,
-            getUserScreenTimeUseCase: getUserScreenTimeUseCase)
-        let shopViewController = ShopViewController(viewModel: viewModel)
-        shopViewController.title = "주변상점"
-        return shopViewController
+            getUserScreenTimeUseCase: getUserScreenTimeUseCase,
+            shopId: shopId,
+            shopName: nil
+        )
+        return ShopSummaryViewController(viewModel: viewModel)
     }
     
     private func makeTimeTableViewController() -> TimetableViewController {
@@ -460,13 +471,14 @@ extension SceneDelegate {
 }
 
 extension SceneDelegate {
-    private func extractValue(from urlString: String?, value: String) -> String? {
-        guard let urlString else {
+    private func parseQuery(uri: String) -> [String: String]? {
+        if let components = URLComponents(string: uri),
+           let qureyItems = components.queryItems {
+            return qureyItems.reduce(into: [:]) { result, item in
+                result[item.name] = item.value
+            }
+        } else {
             return nil
         }
-        let components = URLComponents(string: urlString)
-        print("components : \(components)")
-        print("value: \(components?.queryItems?.first(where: { $0.name == value })?.value)")
-        return components?.queryItems?.first(where: { $0.name == value })?.value
     }
 }

--- a/Koin/Apps/SceneDelegate.swift
+++ b/Koin/Apps/SceneDelegate.swift
@@ -118,17 +118,12 @@ extension SceneDelegate {
         let schemeUri = userInfo["schemeUri"] as? String
         
         switch category {
-        case .home, .login, .club:
-            break
         case .shop:
             let shopViewController = makeShopViewController()
             navigationController?.pushViewController(shopViewController, animated: true)
         case .dining:
             let diningViewController = makeDiningViewController()
             navigationController?.pushViewController(diningViewController, animated: true)
-        case .timeTable:
-            let timeTableViewController = makeTimeTableViewController()
-            navigationController?.pushViewController(timeTableViewController, animated: true)
         case .keyword:
             guard let id = extractValue(from: schemeUri, value: "id"), let intId = Int(id) else {
                 print("noticeId : Invalid or missing")

--- a/Koin/Apps/SceneDelegate.swift
+++ b/Koin/Apps/SceneDelegate.swift
@@ -147,11 +147,9 @@ extension SceneDelegate {
                 navigationController?.pushViewController(callVanDataViewController, animated: true)
             }
         case .callvanChat:
-            if let postId = Int(parsedQuery["postId"]),
-               let chatRoomId = Int(parsedQuery["chatRoomId"]) {
+            if let postId = Int(parsedQuery["postId"]) {
                 let callVanChatViewController = makeCallVanChatViewController(postId: postId)
                 navigationController?.pushViewController(callVanChatViewController, animated: true)
-                
             }
         case .keyword:
             guard let noticeId = Int(parsedQuery["id"]),

--- a/Koin/Apps/SceneDelegate.swift
+++ b/Koin/Apps/SceneDelegate.swift
@@ -13,6 +13,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     var window: UIWindow?
     private var isPresentingErrorViewController = false
     
+    var navigationController: UINavigationController? {
+        (window?.rootViewController as? HomeTabBarController)?.selectedViewController as? UINavigationController
+    }
+    
     // MARK: - Initializer
     override init() {
         super.init()
@@ -42,14 +46,12 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         self.window = window
         window.makeKeyAndVisible()
         
-        // 딥링크
-        let navigationController = (window.rootViewController as? HomeTabBarController)?.selectedViewController as? UINavigationController
-        
+        // MARK: - 딥링크 Cold Start
         if let userActivity = connectionOptions.userActivities.first(where: { $0.activityType == NSUserActivityTypeBrowsingWeb }),
            let incomingURL = userActivity.webpageURL {
-            handleIncomingDeepLink(url: incomingURL, navigationController: navigationController)
+            handleIncomingDeepLink(url: incomingURL)
         } else if let urlContext = connectionOptions.urlContexts.first {
-            handleIncomingDeepLink(url: urlContext.url, navigationController: navigationController)
+            handleIncomingDeepLink(url: urlContext.url)
         }
     }
     
@@ -60,9 +62,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     ) {
         guard userActivity.activityType == NSUserActivityTypeBrowsingWeb,
               let incomingURL = userActivity.webpageURL else { return }
-        
-        let navigationController = (window?.rootViewController as? HomeTabBarController)?.selectedViewController as? UINavigationController
-        handleIncomingDeepLink(url: incomingURL, navigationController: navigationController)
+        handleIncomingDeepLink(url: incomingURL)
     }
     
     // MARK: - 딥링크 (URI Scheme) warm start
@@ -71,22 +71,14 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         openURLContexts URLContexts: Set<UIOpenURLContext>
     ) {
         guard let urlContext = URLContexts.first else { return }
-        let navigationController = (window?.rootViewController as? HomeTabBarController)?.selectedViewController as? UINavigationController
-        handleIncomingDeepLink(url: urlContext.url, navigationController: navigationController)
-    }
-    
-    // MARK: - 푸시알림 처리 (AppDelegate에 의해 호출)
-    func handleNotificationData(userInfo: [AnyHashable: Any]) {
-        let navigationController = (window?.rootViewController as? HomeTabBarController)?.selectedViewController as? UINavigationController
-        handleNotificationData(userInfo: userInfo, navigationController: navigationController)
+        handleIncomingDeepLink(url: urlContext.url)
     }
 }
 
 extension SceneDelegate {
     
     private func handleIncomingDeepLink(
-        url: URL,
-        navigationController: UINavigationController?
+        url: URL
     ) {
         // URL 경로가 "/articles/lost-item"인 경우에 처리
         if url.host == "lost-item" || (url.host == "articles" && url.path == "/lost-item") {
@@ -109,7 +101,8 @@ extension SceneDelegate {
         }
     }
     
-    private func handleNotificationData(userInfo: [AnyHashable: Any], navigationController: UINavigationController?) {
+    // MARK: - 푸시알림 처리
+    func handleNotificationData(userInfo: [AnyHashable: Any]) {
         guard let aps = userInfo["aps"] as? [String: AnyObject], let category = aps["category"] as? String,
               let category = AppPath(rawValue: category) else {
             print("Invalid notification data")
@@ -284,8 +277,7 @@ extension SceneDelegate {
 
     @objc private func presentErrorViewController() {
         
-        guard isPresentingErrorViewController == false,
-              let navigationController = (window?.rootViewController as? UITabBarController)?.selectedViewController as? UINavigationController else {
+        guard isPresentingErrorViewController == false else {
             return
         }
         
@@ -299,13 +291,13 @@ extension SceneDelegate {
             $0.modalPresentationStyle = .fullScreen
         }
         
-        DispatchQueue.main.async {
-            if let _ = navigationController.presentedViewController {
-                navigationController.dismiss(animated: true) {
-                    navigationController.present(errorViewController, animated: true)
+        DispatchQueue.main.async { [weak self] in
+            if let _ = self?.navigationController?.presentedViewController {
+                self?.navigationController?.dismiss(animated: true) {
+                    self?.navigationController?.present(errorViewController, animated: true)
                 }
             } else {
-                navigationController.present(errorViewController, animated: true)
+                self?.navigationController?.present(errorViewController, animated: true)
             }
         }
         isPresentingErrorViewController = true

--- a/Koin/Core/Extensions/Common/Int+.swift
+++ b/Koin/Core/Extensions/Common/Int+.swift
@@ -16,3 +16,9 @@ extension Int {
         return numberFormatter.string(from: NSNumber(value: self)) ?? "\(self)"
     }
 }
+
+extension Int {
+    init?(_ string: String?) {
+        self.init(string ?? "")
+    }
+}

--- a/Koin/Domain/UseCase/Noti/SendDeviceTokenIfNeededUseCase.swift
+++ b/Koin/Domain/UseCase/Noti/SendDeviceTokenIfNeededUseCase.swift
@@ -28,8 +28,7 @@ final class DefaultSendDeviceTokenIfNeededUseCase: SendDeviceTokenIfNeededUseCas
     func execute() {
         Task { [weak self] in
             guard let self,
-                  await self.checkLogin(),
-                  await self.checkNotificationAgreement() else {
+                  await self.checkLogin() else {
                 return
             }
             await self.sendDeviceToken()
@@ -43,14 +42,6 @@ extension DefaultSendDeviceTokenIfNeededUseCase {
         await userRepository.checkLogin()
             .values
             .first { _ in true } ?? false
-    }
-    
-    private func checkNotificationAgreement() async -> Bool {
-        let agreement = await notiRepository.fetchNotiList()
-            .replaceError(with: .init())
-            .values
-            .first { _ in true }
-        return agreement?.isPermit ?? false
     }
     
     private func sendDeviceToken() async {

--- a/Koin/Presentation/Home/Notification/NotificationViewController.swift
+++ b/Koin/Presentation/Home/Notification/NotificationViewController.swift
@@ -162,7 +162,7 @@ extension NotificationViewController {
                let chatRoomIdString = parsedQuery["chatRoomId"],
                let postIdInt = Int(postIdString),
                let chatRoomIdInt = Int(chatRoomIdString) {
-                navigateToChat(postId: postIdInt, chatRoomId: chatRoomIdInt)
+                navigateToCallVanChat(postId: postIdInt, chatRoomId: chatRoomIdInt)
             }
         case .keyword:
             guard let noticeIdString = parsedQuery["id"],
@@ -214,7 +214,7 @@ extension NotificationViewController {
         navigationController?.pushViewController(viewController, animated: true)
     }
     
-    private func navigateToChat(postId: Int, chatRoomId: Int) {
+    private func navigateToCallVanChat(postId: Int, chatRoomId: Int) {
         let viewController = makeCallVanChatViewController(postId: postId)
         navigationController?.pushViewController(viewController, animated: true)
     }

--- a/Koin/Presentation/Home/Notification/NotificationViewController.swift
+++ b/Koin/Presentation/Home/Notification/NotificationViewController.swift
@@ -177,8 +177,6 @@ extension NotificationViewController {
             } else {
                 navigateToKeyword(boardId: boardIdInt, noticeId: noticeIdInt)
             }
-        default:
-            break
         }
     }
     

--- a/Koin/Presentation/Home/Notification/NotificationViewController.swift
+++ b/Koin/Presentation/Home/Notification/NotificationViewController.swift
@@ -152,9 +152,8 @@ extension NotificationViewController {
                 navigateToCallVanData(postId: postId)
             }
         case .callvanChat:
-            if let postId = Int(parsedQuery["postId"]),
-               let chatRoomId = Int(parsedQuery["chatRoomId"]) {
-                navigateToCallVanChat(postId: postId, chatRoomId: chatRoomId)
+            if let postId = Int(parsedQuery["postId"]) {
+                navigateToCallVanChat(postId: postId)
             }
         case .keyword:
             guard let noticeId = Int(parsedQuery["id"]),
@@ -206,7 +205,7 @@ extension NotificationViewController {
         navigationController?.pushViewController(viewController, animated: true)
     }
     
-    private func navigateToCallVanChat(postId: Int, chatRoomId: Int) {
+    private func navigateToCallVanChat(postId: Int) {
         let viewController = makeCallVanChatViewController(postId: postId)
         navigationController?.pushViewController(viewController, animated: true)
     }

--- a/Koin/Presentation/Home/Notification/NotificationViewController.swift
+++ b/Koin/Presentation/Home/Notification/NotificationViewController.swift
@@ -153,7 +153,7 @@ extension NotificationViewController {
                 navigateToChat(articleId: articleIdInt, chatRoomId: chatRoomIdInt)
             }
         case .callvan:
-            if let postIdString = parsedQuery["postId"],
+            if let postIdString = parsedQuery["id"],
                let postIdInt = Int(postIdString) {
                 navigateToCallVanData(postId: postIdInt)
             }

--- a/Koin/Presentation/Home/Notification/NotificationViewController.swift
+++ b/Koin/Presentation/Home/Notification/NotificationViewController.swift
@@ -189,8 +189,8 @@ extension NotificationViewController {
     }
     
     private func navigateToShop(shopId: Int) {
-        let viewController = makeShopViewController()
-        navigationController?.pushViewController(viewController, animated: true)
+        let shopDetailViewController = makeShopSummaryViewController(shopId: shopId)
+        navigationController?.pushViewController(shopDetailViewController, animated: true)
     }
     
     private func navigateToDining() {
@@ -294,28 +294,25 @@ extension NotificationViewController {
         return viewController
     }
     
-    private func makeShopViewController() -> ShopViewController {
-        let shopService = DefaultShopService()
-        let shopRepository = DefaultShopRepository(service: shopService)
-        let fetchShopListUseCase = DefaultFetchShopListUseCase(shopRepository: shopRepository)
-        let fetchEventListUseCase = DefaultFetchEventListUseCase(shopRepository: shopRepository)
-        let fetchShopCategoryListUseCase = DefaultFetchShopCategoryListUseCase(shopRepository: shopRepository)
-        let fetchShopBenefitUseCase = DefaultFetchShopBenefitUseCase(shopRepository: shopRepository)
-        let fetchBeneficialShopUseCase = DefaultFetchBeneficialShopUseCase(shopRepository: shopRepository)
+    private func makeShopSummaryViewController(shopId: Int) -> UIViewController {
+        let repository = DefaultShopRepository(service: DefaultShopService())
+        let fetchOrderShopSummaryFromShopUseCase = DefaultFetchOrderShopSummaryFromShopUseCase(repository: repository)
+        let fetchOrderShopMenusAndGroupsFromShopUseCase = DefaultFetchOrderShopMenusAndGroupsFromShopUseCase(shopRepository: repository)
+        let fetchShopDataUseCase = DefaultFetchShopDataUseCase(shopRepository: repository)
+        let fetchShopEventListUseCase = DefaultFetchShopEventListUseCase(shopRepository: repository)
         let logAnalyticsEventUseCase = DefaultLogAnalyticsEventUseCase(repository: GA4AnalyticsRepository(service: GA4AnalyticsService()))
         let getUserScreenTimeUseCase = DefaultGetUserScreenTimeUseCase()
-        let viewModel = ShopViewModel(
-            fetchShopListUseCase: fetchShopListUseCase,
-            fetchEventListUseCase: fetchEventListUseCase,
-            fetchShopCategoryListUseCase: fetchShopCategoryListUseCase,
-            fetchShopBenefitUseCase: fetchShopBenefitUseCase,
-            fetchBeneficialShopUseCase: fetchBeneficialShopUseCase,
+        let viewModel = ShopSummaryViewModel(
+            fetchOrderShopSummaryFromShopUseCase: fetchOrderShopSummaryFromShopUseCase,
+            fetchOrderShopMenusAndGroupsFromShopUseCase: fetchOrderShopMenusAndGroupsFromShopUseCase,
+            fetchShopDataUseCase: fetchShopDataUseCase,
+            fetchShopEventListUseCase: fetchShopEventListUseCase,
             logAnalyticsEventUseCase: logAnalyticsEventUseCase,
-            getUserScreenTimeUseCase: getUserScreenTimeUseCase
+            getUserScreenTimeUseCase: getUserScreenTimeUseCase,
+            shopId: shopId,
+            shopName: nil
         )
-        let viewController = ShopViewController(viewModel: viewModel)
-        viewController.title = "주변상점"
-        return viewController
+        return ShopSummaryViewController(viewModel: viewModel)
     }
 }
 

--- a/Koin/Presentation/Home/Notification/NotificationViewController.swift
+++ b/Koin/Presentation/Home/Notification/NotificationViewController.swift
@@ -107,8 +107,6 @@ extension NotificationViewController {
             logValue = "콜밴팟"
         case .callvanChat:
             logValue = "콜밴팟 채팅"
-        default:
-            return
         }
         inputSubject.send(.logEvent(EventParameter.EventLabel.Campus.notificationList, .click, logValue))
     }
@@ -139,47 +137,41 @@ extension NotificationViewController {
         }
         switch item.appPath {
         case .shop:
-            if let shopIdString = parsedQuery["id"],
-               let shopIdInt = Int(shopIdString) {
-                navigateToShop(shopId: shopIdInt)
+            if let shopId = Int(parsedQuery["id"]) {
+                navigateToShop(shopId: shopId)
             }
         case .dining:
             navigateToDining()
         case .chat:
-            if let articleIdString = parsedQuery["articleId"],
-               let chatRoomIdString = parsedQuery["chatRoomId"],
-               let articleIdInt = Int(articleIdString),
-               let chatRoomIdInt = Int(chatRoomIdString) {
-                navigateToChat(articleId: articleIdInt, chatRoomId: chatRoomIdInt)
+            if let articleId = Int(parsedQuery["articleId"]),
+               let chatRoomId = Int(parsedQuery["chatRoomId"]) {
+                navigateToChat(articleId: articleId, chatRoomId: chatRoomId)
             }
         case .callvan:
-            if let postIdString = parsedQuery["id"],
-               let postIdInt = Int(postIdString) {
-                navigateToCallVanData(postId: postIdInt)
+            if let postId = Int(parsedQuery["id"]) {
+                navigateToCallVanData(postId: postId)
             }
         case .callvanChat:
-            if let postIdString = parsedQuery["postId"],
-               let chatRoomIdString = parsedQuery["chatRoomId"],
-               let postIdInt = Int(postIdString),
-               let chatRoomIdInt = Int(chatRoomIdString) {
-                navigateToCallVanChat(postId: postIdInt, chatRoomId: chatRoomIdInt)
+            if let postId = Int(parsedQuery["postId"]),
+               let chatRoomId = Int(parsedQuery["chatRoomId"]) {
+                navigateToCallVanChat(postId: postId, chatRoomId: chatRoomId)
             }
         case .keyword:
-            guard let noticeIdString = parsedQuery["id"],
-                  let keyword = parsedQuery["keyword"],
-                  let boardIdString = parsedQuery["board-id"],
-                  let noticeIdInt = Int(noticeIdString),
-                  let boardIdInt = Int(boardIdString) else {
+            guard let noticeId = Int(parsedQuery["id"]),
+                  let boardId = Int(parsedQuery["board-id"]) else {
                 return
             }
-            if boardIdInt == 14 {
-                navigateToLostItemData(lostItemId: noticeIdInt)
+            if boardId == 14 {
+                navigateToLostItemData(lostItemId: noticeId)
             } else {
-                navigateToKeyword(boardId: boardIdInt, noticeId: noticeIdInt)
+                navigateToKeyword(boardId: boardId, noticeId: noticeId)
             }
         }
     }
-    
+}
+
+
+extension NotificationViewController {
     private func parseQuery(uri: String) -> [String: String]? {
         if let components = URLComponents(string: uri),
            let qureyItems = components.queryItems {
@@ -190,7 +182,9 @@ extension NotificationViewController {
             return nil
         }
     }
-    
+}
+
+extension NotificationViewController {
     private func navigateToShop(shopId: Int) {
         let shopDetailViewController = makeShopSummaryViewController(shopId: shopId)
         navigationController?.pushViewController(shopDetailViewController, animated: true)

--- a/Koin/Presentation/Home/Notification/NotificationViewController.swift
+++ b/Koin/Presentation/Home/Notification/NotificationViewController.swift
@@ -165,11 +165,16 @@ extension NotificationViewController {
                 navigateToChat(postId: postIdInt, chatRoomId: chatRoomIdInt)
             }
         case .keyword:
-            if let noticeIdString = parsedQuery["id"],
-               let keyword = parsedQuery["keyword"],
-               let boardIdString = parsedQuery["board-id"],
-               let noticeIdInt = Int(noticeIdString),
-               let boardIdInt = Int(boardIdString) {
+            guard let noticeIdString = parsedQuery["id"],
+                  let keyword = parsedQuery["keyword"],
+                  let boardIdString = parsedQuery["board-id"],
+                  let noticeIdInt = Int(noticeIdString),
+                  let boardIdInt = Int(boardIdString) else {
+                return
+            }
+            if boardIdInt == 14 {
+                navigateToLostItemData(lostItemId: noticeIdInt)
+            } else {
                 navigateToKeyword(boardId: boardIdInt, noticeId: noticeIdInt)
             }
         default:
@@ -211,6 +216,30 @@ extension NotificationViewController {
     
     private func navigateToChat(postId: Int, chatRoomId: Int) {
         let viewController = makeCallVanChatViewController(postId: postId)
+        navigationController?.pushViewController(viewController, animated: true)
+    }
+    
+    private func navigateToLostItemData(lostItemId: Int) {
+        let userRepository = DefaultUserRepository(service: DefaultUserService())
+        let lostItemRepository = DefaultLostItemRepository(service: DefaultLostItemService())
+        let chatRepository = DefaultChatRepository(service: DefaultChatService())
+        let checkLoginUseCase = DefaultCheckLoginUseCase(userRepository: userRepository)
+        let fetchLostItemDataUseCase = DefaultFetchLostItemDataUseCase(repository: lostItemRepository)
+        let fetchLostItemListUseCase = DefaultFetchLostItemListUseCase(repository: lostItemRepository)
+        let changeLostItemStateUseCase = DefaultChangeLostItemStateUseCase(repository: lostItemRepository)
+        let deleteLostItemUseCase = DefaultDeleteLostItemUseCase(repository: lostItemRepository)
+        let createChatRoomUseCase = DefaultCreateChatRoomUseCase(chatRepository: chatRepository)
+        let logAnalyticsEventUseCase = DefaultLogAnalyticsEventUseCase(repository: GA4AnalyticsRepository(service: GA4AnalyticsService()))
+        let viewModel = LostItemDataViewModel(
+            checkLoginUseCase: checkLoginUseCase,
+            fetchLostItemDataUseCase: fetchLostItemDataUseCase,
+            fetchLostItemListUseCase: fetchLostItemListUseCase,
+            changeLostItemStateUseCase: changeLostItemStateUseCase,
+            deleteLostItemUseCase: deleteLostItemUseCase,
+            createChatRoomUseCase: createChatRoomUseCase,
+            logAnalyticsEventUseCase: logAnalyticsEventUseCase,
+            id: lostItemId)
+        let viewController = LostItemDataViewController(viewModel: viewModel)
         navigationController?.pushViewController(viewController, animated: true)
     }
     

--- a/Koin/Presentation/Shop/Shop/ShopViewController.swift
+++ b/Koin/Presentation/Shop/Shop/ShopViewController.swift
@@ -111,15 +111,16 @@ final class ShopViewController: UIViewController {
             let logAnalyticsEventUseCase = DefaultLogAnalyticsEventUseCase(repository: GA4AnalyticsRepository(service: GA4AnalyticsService()))
             let getUserScreenTimeUseCase = DefaultGetUserScreenTimeUseCase()
             let previousPage = self?.viewModel.selectedCategoryName ?? "알 수 없음" 
-            let viewModel = ShopSummaryViewModel(fetchOrderShopSummaryFromShopUseCase: fetchOrderShopSummaryFromShopUseCase,
-                                                 fetchOrderShopMenusAndGroupsFromShopUseCase: fetchOrderShopMenusAndGroupsFromShopUseCase,
-                                                 fetchShopDataUseCase: fetchShopDataUseCase,
-                                                 fetchShopEventListUseCase: fetchShopEventListUseCase,
-                                                 logAnalyticsEventUseCase: logAnalyticsEventUseCase,
-                                                 getUserScreenTimeUseCase: getUserScreenTimeUseCase,
-                                                 shopId: shopId,
-                                                 shopName: shopName,
-                                                 backCategoryName: previousPage
+            let viewModel = ShopSummaryViewModel(
+                fetchOrderShopSummaryFromShopUseCase: fetchOrderShopSummaryFromShopUseCase,
+                fetchOrderShopMenusAndGroupsFromShopUseCase: fetchOrderShopMenusAndGroupsFromShopUseCase,
+                fetchShopDataUseCase: fetchShopDataUseCase,
+                fetchShopEventListUseCase: fetchShopEventListUseCase,
+                logAnalyticsEventUseCase: logAnalyticsEventUseCase,
+                getUserScreenTimeUseCase: getUserScreenTimeUseCase,
+                shopId: shopId,
+                shopName: shopName,
+                backCategoryName: previousPage
             )
             let viewController = ShopSummaryViewController(viewModel: viewModel)
             viewController.title = shopName

--- a/Koin/Presentation/Shop/ShopSummary/ShopSummaryViewController.swift
+++ b/Koin/Presentation/Shop/ShopSummary/ShopSummaryViewController.swift
@@ -145,73 +145,93 @@ extension ShopSummaryViewController {
             .store(in: &subscriptions)
         
         // MARK: - TableHeaderView
-        tableHeaderView.didScrollPublisher.sink { [weak self] contentOffset in
-            self?.menuGroupNameCollectionViewSticky.contentOffset = contentOffset
-        }
-        .store(in: &subscriptions)
+        tableHeaderView.didScrollPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] contentOffset in
+                self?.menuGroupNameCollectionViewSticky.contentOffset = contentOffset
+            }
+            .store(in: &subscriptions)
         
-        tableHeaderView.didSelectCellPublisher.sink { [weak self] indexPath in
-            guard let self = self else { return }
-            let tableViewIndexPath = IndexPath(row: 0, section: indexPath.row)
-            self.menuGroupTableView.scrollToRow(at: tableViewIndexPath, at: .top, animated: true)
-            self.menuGroupNameCollectionViewSticky.configure(selectedIndexPath: indexPath)
-            self.menuGroupNameCollectionViewSticky.selectItem(at: indexPath, animated: true, scrollPosition: .centeredHorizontally)
-        }
-        .store(in: &subscriptions)
+        tableHeaderView.didSelectCellPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] indexPath in
+                guard let self = self else { return }
+                let tableViewIndexPath = IndexPath(row: 0, section: indexPath.row)
+                self.menuGroupTableView.scrollToRow(at: tableViewIndexPath, at: .top, animated: true)
+                self.menuGroupNameCollectionViewSticky.configure(selectedIndexPath: indexPath)
+                self.menuGroupNameCollectionViewSticky.selectItem(at: indexPath, animated: true, scrollPosition: .centeredHorizontally)
+            }
+            .store(in: &subscriptions)
 
-        tableHeaderView.didSwipePicturePublisher.sink { [weak self] in
-            guard let self else { return }
-            self.inputSubject.send(.logEventDirect(EventParameter.EventLabel.Business.shopPictureSwipe, .swipe, self.viewModel.shopName))
-        }.store(in: &subscriptions)
+        tableHeaderView.didSwipePicturePublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] in
+                guard let self else { return }
+                self.inputSubject.send(.logEventDirect(EventParameter.EventLabel.Business.shopPictureSwipe, .swipe, self.viewModel.shopName))
+            }
+            .store(in: &subscriptions)
         
-        tableHeaderView.shouldSetContentInsetPublisher.sink { [weak self] shouldSetContentInset in
-            let topInset = UIApplication.topSafeAreaHeight() + (self?.navigationController?.navigationBar.frame.height ?? 0) + (self?.menuGroupNameCollectionViewSticky.frame.height ?? 0) - 3
-            self?.menuGroupTableView.contentInset = UIEdgeInsets(top: shouldSetContentInset ? topInset : 0, left: 0, bottom: 0, right: 0)
-        }
-        .store(in: &subscriptions)
+        tableHeaderView.shouldSetContentInsetPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] shouldSetContentInset in
+                let topInset = UIApplication.topSafeAreaHeight() + (self?.navigationController?.navigationBar.frame.height ?? 0) + (self?.menuGroupNameCollectionViewSticky.frame.height ?? 0) - 3
+                self?.menuGroupTableView.contentInset = UIEdgeInsets(top: shouldSetContentInset ? topInset : 0, left: 0, bottom: 0, right: 0)
+            }
+            .store(in: &subscriptions)
         
         tableHeaderView.reviewButtonTappedPublisher
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] in
                 self?.navigateToReviewListViewController()
             }
             .store(in: &subscriptions)
         
-        tableHeaderView.navigateToShopInfoPublisher.sink { [weak self] shouldHighlight in
-            guard let self else { return }
-            self.inputSubject.send(.logEventDirect(EventParameter.EventLabel.Business.shopDetailViewInfo, .click, self.viewModel.shopName))
-            let shopService = DefaultShopService()
-            let shopRepository = DefaultShopRepository(service: shopService)
-            let fetchOrderShopDetailFromShopUseCase = DefaultFetchOrderShopDetailFromShopUseCase(repository: shopRepository)
-            let viewModel = ShopDetailViewModel(fetchOrderShopDetailFromShopUseCase: fetchOrderShopDetailFromShopUseCase,
-                                                shopId: self.viewModel.shopId)
-            let viewController = ShopDetailViewController(viewModel: viewModel, shouldHighlight: shouldHighlight)
-            viewController.title = "가게정보"
-            self.navigationController?.pushViewController(viewController, animated: true)
-        }
-        .store(in: &subscriptions)
+        tableHeaderView.navigateToShopInfoPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] shouldHighlight in
+                guard let self else { return }
+                self.inputSubject.send(.logEventDirect(EventParameter.EventLabel.Business.shopDetailViewInfo, .click, self.viewModel.shopName))
+                let shopService = DefaultShopService()
+                let shopRepository = DefaultShopRepository(service: shopService)
+                let fetchOrderShopDetailFromShopUseCase = DefaultFetchOrderShopDetailFromShopUseCase(repository: shopRepository)
+                let viewModel = ShopDetailViewModel(fetchOrderShopDetailFromShopUseCase: fetchOrderShopDetailFromShopUseCase,
+                                                    shopId: self.viewModel.shopId)
+                let viewController = ShopDetailViewController(viewModel: viewModel, shouldHighlight: shouldHighlight)
+                viewController.title = "가게정보"
+                self.navigationController?.pushViewController(viewController, animated: true)
+            }
+            .store(in: &subscriptions)
         
-        tableHeaderView.phoneButtonTappedPublisher.sink { [weak self] in
-            self?.makePhonecall()
-            
-            guard let self else { return }
-            self.inputSubject.send(.getUserScreenAction(Date(), .endEvent, .shopCall))
-            self.inputSubject.send(.logEvent(EventParameter.EventLabel.Business.shopCall, EventParameter.EventCategory.click, self.viewModel.shopName, nil, nil, nil, EventParameter.EventLabelNeededDuration.shopCall))
-        }
-        .store(in: &subscriptions)
+        tableHeaderView.phoneButtonTappedPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] in
+                self?.makePhonecall()
+                
+                guard let self else { return }
+                self.inputSubject.send(.getUserScreenAction(Date(), .endEvent, .shopCall))
+                self.inputSubject.send(.logEvent(EventParameter.EventLabel.Business.shopCall, EventParameter.EventCategory.click, self.viewModel.shopName, nil, nil, nil, EventParameter.EventLabelNeededDuration.shopCall))
+            }
+            .store(in: &subscriptions)
         
-        tableHeaderView.benefitButtonTappedPublisher.sink { [weak self] in
-            guard let self else { return }
-            self.inputSubject.send(.logEvent(EventParameter.EventLabel.Business.shopBenefitEntry, .click, self.viewModel.shopName, nil, nil, nil, nil))
-            navigateToShopBenefit()
-        }.store(in: &subscriptions)
+        tableHeaderView.benefitButtonTappedPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] in
+                guard let self else { return }
+                self.inputSubject.send(.logEvent(EventParameter.EventLabel.Business.shopBenefitEntry, .click, self.viewModel.shopName, nil, nil, nil, nil))
+                navigateToShopBenefit()
+            }
+            .store(in: &subscriptions)
         
         // MARK: - GroupNameCollectionView
-        menuGroupNameCollectionViewSticky.didScrollPublisher.sink { [weak self] contentOffset in
-            self?.tableHeaderView.update(contentOffset: contentOffset)
-        }
-        .store(in: &subscriptions)
+        menuGroupNameCollectionViewSticky.didScrollPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] contentOffset in
+                self?.tableHeaderView.update(contentOffset: contentOffset)
+            }
+            .store(in: &subscriptions)
         
         menuGroupNameCollectionViewSticky.didSelectCellPublisher
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] indexPath in
                 guard let self = self else { return }
                 let tableViewIndexPath = IndexPath(row: 0, section: indexPath.row)
@@ -224,6 +244,7 @@ extension ShopSummaryViewController {
         
         // MARK: - tableView
         menuGroupTableView.updateNavigationBarPublisher
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] navigationBarItemColor, navigationBarAlpha in
                 self?.navigationBarItemColor = navigationBarItemColor
                 self?.navigationBarAlpha = navigationBarAlpha
@@ -231,12 +252,14 @@ extension ShopSummaryViewController {
             }.store(in: &subscriptions)
         
         menuGroupTableView.shouldShowStickyPublisher
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] shouldShowSticky in
                 self?.menuGroupNameCollectionViewSticky.isHidden = !shouldShowSticky
             }
             .store(in: &subscriptions)
         
         menuGroupTableView.shouldSetContentInsetPublisher
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] shouldSetContentInset in
                 let topInset = UIApplication.topSafeAreaHeight() + (self?.navigationController?.navigationBar.frame.height ?? 0) + (self?.menuGroupNameCollectionViewSticky.frame.height ?? 0) - 3
                 self?.menuGroupTableView.contentInset = UIEdgeInsets(top: shouldSetContentInset ? topInset : 0, left: 0, bottom: 0, right: 0)
@@ -244,6 +267,7 @@ extension ShopSummaryViewController {
             .store(in: &subscriptions)
         
         menuGroupTableView.didEndScrollPublisher
+            .receive(on: DispatchQueue.main)
             .sink { [ weak self ] in
                 guard let self else { return }
                 if !self.hasLoggedInitialScroll {
@@ -254,6 +278,7 @@ extension ShopSummaryViewController {
             .store(in: &subscriptions)
 
         menuGroupTableView.didTapThumbnailPublisher
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] imageUrl in
                 guard let self else { return }
                 let zoomedViewController = ZoomedImageViewControllerB(shouldShowTitle: false)
@@ -264,12 +289,14 @@ extension ShopSummaryViewController {
 
         // MARK: - PopUpView
         popUpView.leftButtonTappedPublisher
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] in
                 self?.hidePopUpView()
             }
             .store(in: &subscriptions)
         
         popUpView.rightButtonTappedPublisher
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] menuId in
                 self?.hidePopUpView()
                 self?.navigateToMenuDetail(menuId: menuId)
@@ -278,6 +305,7 @@ extension ShopSummaryViewController {
         
         // MARK: - ThumbnailImage
         tableHeaderView.didTapThumbnailPublisher
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] indexPath in
                 guard let self,
                       0 < self.viewModel.cachedImages.count,

--- a/Koin/Presentation/Shop/ShopSummary/ShopSummaryViewController.swift
+++ b/Koin/Presentation/Shop/ShopSummary/ShopSummaryViewController.swift
@@ -111,35 +111,38 @@ extension ShopSummaryViewController {
     
     // MARK: - bind
     private func bind() {
-        let output = viewModel.transform(with: inputSubject.eraseToAnyPublisher())
-        output.sink { [weak self] output in
-            guard let self else { return }
-            switch output {
-            case let .update1(images, name, rating, reviewCount):
-                self.viewModel.cachedImages = images
-                self.tableHeaderView.configure1(
-                    images: images,
-                    name: name,
-                    rating: rating,
-                    reviewCount: reviewCount
-                )
-                break
-            case let .update2(delivery, payBank, payCard, maxDeliveryTip, phonenumber):
-                self.tableHeaderView.configure2(
-                    delivery: delivery,
-                    payBank: payBank,
-                    payCard: payCard,
-                    maxDeliveryTip: maxDeliveryTip,
-                    phonenumber: phonenumber)
-            case let .update3(menusGroups, menus):
-                self.tableHeaderView.configure3(orderShopMenusGroups: menusGroups)
-                self.menuGroupNameCollectionViewSticky.configure(menuGroup: menusGroups.menuGroups)
-                self.menuGroupTableView.configure(menus)
-            case let .updateShopEvent(event):
-                self.tableHeaderView.configure(event: event ?? "아직 이벤트가 없어요.")
+        viewModel.transform(with: inputSubject.eraseToAnyPublisher())
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] output in
+                guard let self else { return }
+                switch output {
+                case let .update1(images, name, rating, reviewCount):
+                    self.viewModel.cachedImages = images
+                    self.tableHeaderView.configure1(
+                        images: images,
+                        name: name,
+                        rating: rating,
+                        reviewCount: reviewCount
+                    )
+                    break
+                case let .update2(delivery, payBank, payCard, maxDeliveryTip, phonenumber):
+                    self.tableHeaderView.configure2(
+                        delivery: delivery,
+                        payBank: payBank,
+                        payCard: payCard,
+                        maxDeliveryTip: maxDeliveryTip,
+                        phonenumber: phonenumber)
+                case let .update3(menusGroups, menus):
+                    self.tableHeaderView.configure3(orderShopMenusGroups: menusGroups)
+                    self.menuGroupNameCollectionViewSticky.configure(menuGroup: menusGroups.menuGroups)
+                    self.menuGroupTableView.configure(menus)
+                case let .updateShopEvent(event):
+                    self.tableHeaderView.configure(event: event ?? "아직 이벤트가 없어요.")
+                case let .updateTitle(title):
+                    self.title = title
+                }
             }
-        }
-        .store(in: &subscriptions)
+            .store(in: &subscriptions)
         
         // MARK: - TableHeaderView
         tableHeaderView.didScrollPublisher.sink { [weak self] contentOffset in

--- a/Koin/Presentation/Shop/ShopSummary/ShopSummaryViewModel.swift
+++ b/Koin/Presentation/Shop/ShopSummary/ShopSummaryViewModel.swift
@@ -123,6 +123,7 @@ extension ShopSummaryViewModel {
             receiveValue: { [weak self] in
                 guard let self else { return }
                 self.phonenumber = $0.phone
+                self.shopName = $0.name
                 self.outputSubject.send(.updateTitle($0.name))
                 self.outputSubject.send(.update2(
                     delivery: $0.delivery,

--- a/Koin/Presentation/Shop/ShopSummary/ShopSummaryViewModel.swift
+++ b/Koin/Presentation/Shop/ShopSummary/ShopSummaryViewModel.swift
@@ -24,6 +24,7 @@ final class ShopSummaryViewModel {
         case update2(delivery: Bool, payBank: Bool, payCard: Bool, maxDeliveryTip: Int = 0, phone: String)
         case update3(menusGroups: OrderShopMenusGroups, menus: [OrderShopMenus])
         case updateShopEvent(event: String?)
+        case updateTitle(String)
     }
     
     // MARK: - Properties
@@ -32,7 +33,7 @@ final class ShopSummaryViewModel {
     private(set) var shopId: Int
     private(set) var phonenumber: String = ""
     var cachedImages: [OrderImage] = []
-    let shopName: String
+    private(set) var shopName: String
     let backCategoryName: String?
 
     private let fetchOrderShopSummaryFromShopUseCase: FetchOrderShopSummaryFromShopUseCase
@@ -51,14 +52,14 @@ final class ShopSummaryViewModel {
          logAnalyticsEventUseCase: LogAnalyticsEventUseCase,
          getUserScreenTimeUseCase: GetUserScreenTimeUseCase,
          shopId: Int,
-         shopName: String,
+         shopName: String?,
          backCategoryName: String? = nil) {
         self.fetchOrderShopSummaryFromShopUseCase = fetchOrderShopSummaryFromShopUseCase
         self.fetchOrderShopMenusAndGroupsFromShopUseCase = fetchOrderShopMenusAndGroupsFromShopUseCase
         self.fetchShopDataUseCase = fetchShopDataUseCase
         self.fetchShopEventListUseCase = fetchShopEventListUseCase
         self.shopId = shopId
-        self.shopName = shopName
+        self.shopName = shopName ?? ""
         self.backCategoryName = backCategoryName
         self.logAnalyticsEventUseCase = logAnalyticsEventUseCase
         self.getUserScreenTimeUseCase = getUserScreenTimeUseCase
@@ -122,6 +123,7 @@ extension ShopSummaryViewModel {
             receiveValue: { [weak self] in
                 guard let self else { return }
                 self.phonenumber = $0.phone
+                self.outputSubject.send(.updateTitle($0.name))
                 self.outputSubject.send(.update2(
                     delivery: $0.delivery,
                     payBank: $0.payBank,


### PR DESCRIPTION
## #️⃣연관된 이슈

- #494

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

1. 이동할 화면 변경
    - 주변상점 알림 선택시, 상점목록이 아닌 상점상세으로 이동하도록 변경했습니다.
    - 키워드 알림 선택시 분실물/게시판을 구분하여 화면전환하도록 변경했습니다.

2. schemeUri 파싱 수정
    - 콜밴 파싱 시 postId가 아니라 id를 파싱하도록 변경했습니다.
    - 콜밴채팅 파싱시 불필요한 chatRoomId 를 삭제했습니다.

3. 푸시알림을 통한 Cold Start시 화면전환 실패 수정
    - 푸시알림을 통한 Cold Start시 AppDelegate의 userNotificationCenter(_:didReceive:withCompletionHandler) 에서 sceneDelegate가 nil인 경우 화면전환에 실패합니다.
    - SceneDelegate의 scene(_:willConnectTo:options:)에 푸시알림을 통한 화면전환 로직을 추가했습니다.
    - 푸시알림을 통한 Cold Start시 AppDelegate의 userNotificationCenter(_:didReceive:withCompletionHandler) 에서 sceneDelegate가 nil이 아닌 경우 화면전환 메서드 중복 호출을 방지하지 위해, SceneDelegate에 handledMessageIds: [String] 프로퍼티를 추가했습니다.

4. fcm 토큰 등록 실패 수정
    - NotiAgreementDto.isPermit 을 잘못 이해하고 isPermit이 false인 경우 fcm 토큰을 등록하지 않고 있었습니다.
    - SendDeviceTokenIfNeededUseCase에서 NotiAgreementDto.isPermit 확인 과정을 삭제했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved notification and deep-link navigation to open the correct chat, call service, shop, notice, or lost-item destination.
  * Added lost-item detail navigation from relevant notifications.
  * Shop summary screens now update their title using the fetched shop name.
* **Bug Fixes**
  * Prevented duplicate handling of notification taps.
  * Improved notification routing when multiple app scenes are active.
  * Ensured shop summary interactions and UI updates are handled reliably.
* **Improvements**
  * Device tokens can now be sent after login without requiring notification agreement status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->