### PR TITLE
fix: 홈화면 프로필 시간표 UI 오류 수정

### DIFF
--- a/Koin/Presentation/Home/Profile/Subviews/TimeTableView/Subviews/TimeTableEmptyLectureView.swift
+++ b/Koin/Presentation/Home/Profile/Subviews/TimeTableView/Subviews/TimeTableEmptyLectureView.swift
@@ -10,18 +10,10 @@ import SwiftUI
 struct TimeTableEmptyLectureView: View {
     
     var body: some View {
-        VStack(spacing: 0) {
-            Group {
-                Color.clear
-                
-                Color.clear
-            }
-            .frame(maxHeight: .infinity)
+        Color.clear
             .border(
                 Color.appColor(.neutral100),
                 width: TimeTableView.Layout.Separator.thin,
                 edges: [.bottom, .trailing])
-        }
-        .frame(height: TimeTableView.Layout.timeHeight)
     }
 }

--- a/Koin/Presentation/Home/Profile/Subviews/TimeTableView/Subviews/TimeTableHourView.swift
+++ b/Koin/Presentation/Home/Profile/Subviews/TimeTableView/Subviews/TimeTableHourView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct TimeTableHourView: View {
     
-    let hours: ClosedRange<Int> = 9...18
+    let hours: Range<Int> = TimeTableView.Layout.startHour..<TimeTableView.Layout.endHour
     
     var body: some View {
         VStack(spacing: 0) {

--- a/Koin/Presentation/Home/Profile/Subviews/TimeTableView/Subviews/TimeTableLectureContainerView.swift
+++ b/Koin/Presentation/Home/Profile/Subviews/TimeTableView/Subviews/TimeTableLectureContainerView.swift
@@ -23,8 +23,6 @@ enum TimeTableRow: Identifiable {
 
 struct TimeTableLectureContainerView: View {
 
-    let numberOfRows: Int = 10
-
     var rows: [TimeTableRow] = []
     
     init(
@@ -39,14 +37,14 @@ struct TimeTableLectureContainerView: View {
                 switch row {
                 case .empty:
                     TimeTableEmptyLectureView()
-                        .frame(height: TimeTableView.Layout.timeHeight)
+                        .frame(height: TimeTableView.Layout.slotHeight)
                 case .some(_, let wrapper, let times):
                     TimeTableLectureView(
                         headerColor: wrapper.header,
                         bodyColor: wrapper.body,
                         lecture: wrapper.lecture
                     )
-                    .frame(height: TimeTableView.Layout.timeHeight * times)
+                    .frame(height: TimeTableView.Layout.slotHeight * times)
                 }
             }
         }
@@ -56,10 +54,10 @@ struct TimeTableLectureContainerView: View {
 extension TimeTableLectureContainerView {
     
     private func makeRows(wrappers: [LectureDataWrapper]) -> [TimeTableRow] {
-        func findLecture(at row: Int) -> LectureDataWrapper? {
+        func findLecture(at slot: Int) -> LectureDataWrapper? {
             return wrappers.first(where: {
                 if let _ = $0.lecture.classTime.first(where: {
-                    $0 % 10 == row
+                    $0 % 100 == slot
                 }) {
                     return true
                 } else {
@@ -70,11 +68,11 @@ extension TimeTableLectureContainerView {
         
         var result: [TimeTableRow] = []
         
-        for row in 0..<numberOfRows {
-            if let wrapper = findLecture(at: row) {
-                result.append(TimeTableRow.some(at: row, wrapper))
+        for slot in 0..<TimeTableView.Layout.numberOfSlots {
+            if let wrapper = findLecture(at: slot) {
+                result.append(TimeTableRow.some(at: slot, wrapper))
             } else {
-                result.append(TimeTableRow.empty(at: row))
+                result.append(TimeTableRow.empty(at: slot))
             }
         }
         
@@ -95,4 +93,3 @@ extension TimeTableLectureContainerView {
         }
     }
 }
-

--- a/Koin/Presentation/Home/Profile/Subviews/TimeTableView/TimeTableView.swift
+++ b/Koin/Presentation/Home/Profile/Subviews/TimeTableView/TimeTableView.swift
@@ -35,6 +35,11 @@ struct TimeTableView: View {
         static let dayHeight: CGFloat = 16
         static let timeWidth: CGFloat = 30
         static let timeHeight: CGFloat = 29
+        static let startHour: Int = 9
+        static let endHour: Int = 19
+        static let slotsPerHour: Int = 2
+        static let numberOfSlots: Int = (endHour - startHour) * slotsPerHour
+        static let slotHeight: CGFloat = timeHeight / CGFloat(slotsPerHour)
         static let headerWidth: CGFloat = 2
         enum Separator {
             static let bold: CGFloat = 1


### PR DESCRIPTION
## #️⃣연관된 이슈

- #507 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

API는 30분 단위, UI는 1시간 단위로 만들어서 발생한 오류를 수정했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved timetable rendering by aligning displayed hours, rows, and lecture slots with the configured schedule.
  - Corrected lecture matching for multi-slot timetable entries.
  - Updated row sizing to provide consistent spacing for empty and occupied lecture slots.
  - Simplified empty timetable cell rendering while preserving separator borders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->