### PR TITLE
fix: 부서정보 화면 UI 개선

### DIFF
--- a/Koin/Presentation/Department/Department/DepartmentView.swift
+++ b/Koin/Presentation/Department/Department/DepartmentView.swift
@@ -58,14 +58,17 @@ struct DepartmentView: ActionBindableView {
                         
                         Spacer()
                         
-                        DepartmentFooterView(updatedAt: isSearching ? viewModel.searchingUpdatedAt : viewModel.updatedAt)
+                        if !(isSearching && !viewModel.isLoading && viewModel.searchingDepartments.isEmpty) {
+                            DepartmentFooterView(updatedAt: isSearching ? viewModel.searchingUpdatedAt : viewModel.updatedAt)
+                        }
                     }
                     .hideKeyboardWhenTapAround()
                     .containerShape(.rect)
-                    .overlay {
-                        if isSearching && viewModel.searchingDepartments.isEmpty && !viewModel.isLoading {
-                            DepartmentEmptyView()
-                        }
+                }
+                .frame(minHeight: proxy.size.height)
+                .background {
+                    if isSearching && !viewModel.isLoading && viewModel.searchingDepartments.isEmpty {
+                        DepartmentEmptyView()
                     }
                 }
                 .padding(.horizontal, 22)

--- a/Koin/Presentation/Department/Department/Subviews/DepartmentManyTasksView.swift
+++ b/Koin/Presentation/Department/Department/Subviews/DepartmentManyTasksView.swift
@@ -50,6 +50,9 @@ struct DepartmentManyTasksView: View {
                     Text(task.name)
                         .font(.appFont(.pretendardMedium, size: 12))
                         .foregroundStyle(Color.appColor(.neutral500))
+                        .multilineTextAlignment(.center)
+                        .lineLimit(2)
+                        .padding(.horizontal, 10)
                         .frame(maxWidth: .infinity)
                     
                     Button {

--- a/Koin/Presentation/Department/DepartmentCategory/DepartmentCategoryView.swift
+++ b/Koin/Presentation/Department/DepartmentCategory/DepartmentCategoryView.swift
@@ -71,6 +71,10 @@ struct DepartmentCategoryView: ActionBindableView {
                         }
                         
                         Spacer()
+                        
+                        if isSearching {
+                            DepartmentFooterView(updatedAt: viewModel.searchingUpdatedAt)
+                        }
                     }
                     .hideKeyboardWhenTapAround()
                     .overlay {

--- a/Koin/Presentation/Department/DepartmentCategory/DepartmentCategoryView.swift
+++ b/Koin/Presentation/Department/DepartmentCategory/DepartmentCategoryView.swift
@@ -72,15 +72,15 @@ struct DepartmentCategoryView: ActionBindableView {
                         
                         Spacer()
                         
-                        if isSearching {
+                        if isSearching && !viewModel.isLoading && !viewModel.searchingDepartments.isEmpty {
                             DepartmentFooterView(updatedAt: viewModel.searchingUpdatedAt)
                         }
                     }
                     .hideKeyboardWhenTapAround()
-                    .overlay {
-                        if isSearching && viewModel.searchingDepartments.isEmpty && !viewModel.isLoading {
-                            DepartmentEmptyView()
-                        }
+                }
+                .background {
+                    if isSearching && !viewModel.isLoading && viewModel.searchingDepartments.isEmpty {
+                        DepartmentEmptyView()
                     }
                 }
                 .padding(.horizontal, Layout.horizontalPadding)

--- a/Koin/Presentation/Department/DepartmentCategory/Subviews/DepartmentSearchView.swift
+++ b/Koin/Presentation/Department/DepartmentCategory/Subviews/DepartmentSearchView.swift
@@ -46,7 +46,9 @@ struct DepartmentSearchView: View {
             .padding(.leading, 20)
             .onSubmit {
                 keyword = keyword.trimmingCharacters(in: .whitespacesAndNewlines)
-                searchButtonTapped(keyword)
+                if !keyword.isEmpty {
+                    searchButtonTapped(keyword)
+                }
             }
             
             Spacer()
@@ -72,6 +74,7 @@ struct DepartmentSearchView: View {
                     .padding(EdgeInsets(top: 0, leading: 10, bottom: 0, trailing: 20))
             }
             .buttonStyle(.plain)
+            .disabled(keyword.isEmpty)
         }
         .frame(height: Layout.height)
         .frame(maxWidth: .infinity)


### PR DESCRIPTION
## #️⃣연관된 이슈

- #512 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

부서정보 화면 UI를 개선했습니다.

1. 검색화면 UI 개선
    - TextField에 입력한 값이 없을 때 검색버튼이 동작하지 않도록 개선했습니다.
    - 아래로 쏠려보이던 EmptyView를 개선했습니다.

2. 부서정보 화면 UI 개선
    - 누락되어있던 VStack의 minHeight를 추가하여, Footer가 항상 화면 최하단에 오도록 했습니다.
    - 업무 내용이 길어졌을 때 Text와 Border가 붙어보이지 않도록 패딩을 추가했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
